### PR TITLE
Add services highlight ring tracking

### DIFF
--- a/scripts/services.js
+++ b/scripts/services.js
@@ -1,17 +1,102 @@
-// SwiftSend Max 3.0 — Services (scaffold)
-// This file intentionally does nothing yet. It’s here so we can
-// add pointer-tracking, reveal animations, or metrics later.
-
 (() => {
-    'use strict';
-  
-    const section = document.getElementById('services');
-    if (!section) return; // Exit early until the Services markup is added.
-  
-    // Example scaffold (kept disabled for now):
-    // const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    // if (!prefersReduced) {
-    //   // hook up observers / interactions in future steps
-    // }
-  })();
-  
+  'use strict';
+
+  const section = document.getElementById('services');
+  if (!section) return;
+
+  const highlight = section.querySelector('.highlight-ring');
+  const cards = Array.from(section.querySelectorAll('.service-card'));
+  if (!highlight || cards.length === 0) return;
+
+  const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let prefersReduced = reduceMotionQuery.matches;
+
+  const positioningRoot = highlight.offsetParent instanceof HTMLElement
+    ? highlight.offsetParent
+    : section;
+
+  let activeCard = null;
+
+  const isElement = (value) => value instanceof Element;
+
+  const setPosition = (card) => {
+    const cardRect = card.getBoundingClientRect();
+    const rootRect = positioningRoot.getBoundingClientRect();
+    const x = cardRect.left + cardRect.width / 2 - rootRect.left;
+    const y = cardRect.top + cardRect.height / 2 - rootRect.top;
+
+    highlight.style.setProperty('--x', `${x}px`);
+    highlight.style.setProperty('--y', `${y}px`);
+  };
+
+  const showHighlight = (card) => {
+    activeCard = card;
+    setPosition(card);
+    highlight.classList.add('is-active');
+    highlight.removeAttribute('aria-hidden');
+  };
+
+  const hideHighlight = () => {
+    activeCard = null;
+    highlight.classList.remove('is-active');
+    highlight.setAttribute('aria-hidden', 'true');
+  };
+
+  const handleEnter = (event) => {
+    if (prefersReduced && event.type === 'mouseenter') return;
+    showHighlight(event.currentTarget);
+  };
+
+  const handleLeave = (event) => {
+    const nextTarget = event.relatedTarget;
+    if (isElement(nextTarget) && (nextTarget === highlight || nextTarget.closest('.service-card')))
+      return;
+
+    hideHighlight();
+  };
+
+  const handleBlur = (event) => {
+    const next = event.relatedTarget;
+    if (isElement(next) && next.closest('.service-card')) return;
+
+    hideHighlight();
+  };
+
+  const handleMotionChange = (event) => {
+    prefersReduced = event.matches;
+
+    if (prefersReduced) {
+      if (!section.querySelector('.service-card:focus')) hideHighlight();
+      return;
+    }
+
+    const focusedCard = section.querySelector('.service-card:focus');
+    if (focusedCard) {
+      showHighlight(focusedCard);
+    } else if (activeCard) {
+      showHighlight(activeCard);
+    }
+  };
+
+  if (typeof reduceMotionQuery.addEventListener === 'function') {
+    reduceMotionQuery.addEventListener('change', handleMotionChange);
+  } else if (typeof reduceMotionQuery.addListener === 'function') {
+    reduceMotionQuery.addListener(handleMotionChange);
+  }
+
+  cards.forEach((card) => {
+    card.addEventListener('mouseenter', handleEnter);
+    card.addEventListener('focus', handleEnter);
+    card.addEventListener('mouseleave', handleLeave);
+    card.addEventListener('blur', handleBlur);
+  });
+
+  section.addEventListener('mouseleave', (event) => {
+    const nextTarget = event.relatedTarget;
+    if (isElement(nextTarget) && section.contains(nextTarget)) return;
+
+    hideHighlight();
+  });
+
+  hideHighlight();
+})();


### PR DESCRIPTION
## Summary
- track the services highlight ring element and move it with hovered or focused cards
- respect reduced-motion preferences while keeping keyboard focus support and hide-on-leave behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d348d9ef0c832fa387dd51f1ab488e