### PR TITLE
Add services section markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,58 @@
     </div>
   </section>
 
+  <section id="services" class="services">
+    <span class="highlight-ring" aria-hidden="true"></span>
+    <div class="services-inner">
+      <header class="services-head">
+        <p class="eyebrow">Services</p>
+        <h2 class="services-title">Build, launch, and scale without the bloat</h2>
+        <p class="services-sub">
+          From concept to continual optimization, SwiftSend pairs product thinking with pragmatic engineering to deliver outcomes
+          that move faster and cost less than bloated agencies.
+        </p>
+      </header>
+
+      <div class="services-grid">
+        <article class="service-card">
+          <div class="service-icon" aria-hidden="true"></div>
+          <h3 class="service-title">Product Strategy</h3>
+          <p class="service-desc">Rapid discovery sprints turn messy ideas into validated roadmaps your stakeholders can trust.</p>
+        </article>
+
+        <article class="service-card">
+          <div class="service-icon" aria-hidden="true"></div>
+          <h3 class="service-title">Custom Development</h3>
+          <p class="service-desc">Modern web, mobile, and platform builds using frameworks that fit your team—not the other way around.</p>
+        </article>
+
+        <article class="service-card">
+          <div class="service-icon" aria-hidden="true"></div>
+          <h3 class="service-title">Data Engineering</h3>
+          <p class="service-desc">Pipelines, warehouses, and semantic layers that keep insights fresh and reliable across the org.</p>
+        </article>
+
+        <article class="service-card">
+          <div class="service-icon" aria-hidden="true"></div>
+          <h3 class="service-title">AI Automation</h3>
+          <p class="service-desc">Integrate LLM copilots, agents, and automations to eliminate manual toil and unlock new value streams.</p>
+        </article>
+
+        <article class="service-card">
+          <div class="service-icon" aria-hidden="true"></div>
+          <h3 class="service-title">Growth Experiments</h3>
+          <p class="service-desc">Test offers, funnels, and lifecycle touchpoints with data-backed iteration loops that actually ship.</p>
+        </article>
+
+        <article class="service-card">
+          <div class="service-icon" aria-hidden="true"></div>
+          <h3 class="service-title">Sustained Delivery</h3>
+          <p class="service-desc">Embedded pods keep your roadmap humming with on-demand velocity, observability, and support.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
   <script src="./scripts/header.js" type="module"></script>
   <script src="./scripts/hero.js" type="module"></script>
   <!-- Services script (safe placeholder; will power interactions later) -->


### PR DESCRIPTION
## Summary
- add the Services section markup after the hero with header copy and six cards
- include the decorative highlight ring span scaffolded for future styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d348d61318832f94504556003891b2