### PR TITLE
Adjust header overlay behavior

### DIFF
--- a/scripts/header.js
+++ b/scripts/header.js
@@ -9,9 +9,16 @@ const mobile = document.getElementById('mobileMenu');
 const closeBtn = mobile?.querySelector('.overlay-close');
 const hero = document.querySelector('.hero');
 
+const HEADER_FADE_MIN = 120;   // never add fade before this scroll distance
+const HEADER_FADE_MAX = 220;   // keep the veil subtle even if threshold changes
+const HEADER_FADE_THRESHOLD = 220; // existing logic target
+const HEADER_FADE_SAFE = Math.min(Math.max(HEADER_FADE_THRESHOLD, HEADER_FADE_MIN), HEADER_FADE_MAX);
+
 // -------- Header blend logic --------
 function applyHeaderBlend() {
   if (!header) return;
+
+  const y = window.scrollY || document.documentElement.scrollTop;
 
   // If the hero is still beneath the header, keep it transparent.
   if (hero) {
@@ -23,10 +30,14 @@ function applyHeaderBlend() {
     }
   }
 
+  // Guard so the veil never appears during the initial tiny scroll.
+  if (y <= HEADER_FADE_MIN) {
+    header.classList.remove('header-fade');
+    return;
+  }
+
   // Only after we’re well past the hero, add a faint veil.
-  const y = window.scrollY || document.documentElement.scrollTop;
-  const THRESHOLD = 220; // generous threshold to avoid looking like a dark bar
-  header.classList.toggle('header-fade', y > THRESHOLD);
+  header.classList.toggle('header-fade', y > HEADER_FADE_SAFE);
 }
 
 // Initialize + listeners

--- a/styles/header.css
+++ b/styles/header.css
@@ -2,23 +2,26 @@
    SwiftSend Max 3.0 — Header (overlay, transparent, non-sticky)
    =========================== */
 
-   .ss-header{
-    /* Overlay the hero so its gradient shows through the transparent header */
-    position:absolute; top:0; left:0; right:0;
-    z-index:50;
-    width:100%;
-    background: transparent !important;   /* no bar */
-    border: none;
-    -webkit-backdrop-filter: blur(12px);
-    backdrop-filter: blur(12px);
-    transition: background .25s cubic-bezier(.2,.8,.2,1), border-color .25s cubic-bezier(.2,.8,.2,1);
-  }
-  
-  /* If JS adds .header-fade after long scroll, keep it barely visible */
-  .ss-header.header-fade{
-    background: linear-gradient(90deg, rgba(25,16,40,.04), rgba(100,28,102,.04)) !important;
-    border-bottom: 1px solid rgba(255,255,255,.05);
-  }
+.ss-header{
+  /* Overlay the hero so its gradient shows through the transparent header */
+  position:absolute;
+  top:0;
+  left:0;
+  right:0;
+  z-index:50;
+  width:100%;
+  background:transparent !important;   /* no bar */
+  border:none;
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  transition:background .25s cubic-bezier(.2,.8,.2,1), border-color .25s cubic-bezier(.2,.8,.2,1);
+}
+
+/* If JS adds .header-fade after long scroll, keep it barely visible */
+.ss-header.header-fade{
+  background:linear-gradient(90deg, rgba(25,16,40,.035), rgba(100,28,102,.035)) !important;
+  border-bottom:1px solid rgba(255,255,255,.045);
+}
   
   .header-row{
     display:flex; align-items:center; justify-content:space-between;


### PR DESCRIPTION
## Summary
- keep the header positioned absolutely at the top of the page while retaining the transparent, blurred overlay styling
- soften the optional header-fade treatment so it remains a subtle veil over the hero
- guard the scroll logic so the fade is only applied after the hero clears the header and the scroll distance exceeds the safe threshold

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d378a20fbc832fa51b50bbac683aed