### PR TITLE
Add portfolio section with animated case studies

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="./styles/hero.css" />
   <!-- Services styles (scoped, safe even before the section exists) -->
   <link rel="stylesheet" href="./styles/services.css" />
+  <link rel="stylesheet" href="./styles/portfolio.css" />
 </head>
 <body>
   <!-- Header -->
@@ -231,9 +232,81 @@
     </div>
   </section>
 
+  <section id="portfolio" class="portfolio" aria-labelledby="portfolio-title">
+    <div class="portfolio__inner">
+      <header class="portfolio__head">
+        <h2 id="portfolio-title" class="portfolio__title">Work That <span class="grad">Stands Out</span></h2>
+        <p class="portfolio__lede">Real projects, real results, real impact.</p>
+      </header>
+
+      <div class="portfolio__grid">
+        <!-- RealtorDemo -->
+        <article class="pf-card" data-key="realtor" style="--bar-progress:0.90;">
+          <div class="pf-card__media" aria-hidden="true">
+            <img src="images/portfolio-realtor.jpg" alt="Real estate platform interface" loading="lazy">
+            <span class="pf-card__pill">Real Estate Platform</span>
+            <button class="pf-card__ext" aria-label="Open RealtorDemo case study" tabindex="-1">
+              <!-- external icon: simple box-with-arrow glyph via inline SVG -->
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3zM5 5h6v2H7v10h10v-4h2v6H5V5z"/></svg>
+            </button>
+          </div>
+          <div class="pf-card__body">
+            <h3 class="pf-card__title">RealtorDemo</h3>
+            <p class="pf-card__row"><span class="label label--problem">Problem:</span> Traditional MLS listings with poor lead generation</p>
+            <p class="pf-card__row"><span class="label label--build">Build:</span> Modern property search with integrated lead capture system</p>
+            <p class="pf-card__row"><span class="label label--outcome">Outcome:</span> <span>+32% leads</span> <span class="pf-card__trend" aria-hidden="true">▲</span></p>
+            <div class="pf-card__bar"><span class="pf-card__fill"></span></div>
+          </div>
+        </article>
+
+        <!-- NailTechDemo -->
+        <article class="pf-card" data-key="nailtech" style="--bar-progress:0.88;">
+          <div class="pf-card__media" aria-hidden="true">
+            <img src="images/portfolio-nailtech.jpg" alt="Beauty & wellness booking environment" loading="lazy">
+            <span class="pf-card__pill">Beauty & Wellness</span>
+            <button class="pf-card__ext" aria-label="Open NailTechDemo case study" tabindex="-1">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3zM5 5h6v2H7v10h10v-4h2v6H5V5z"/></svg>
+            </button>
+          </div>
+          <div class="pf-card__body">
+            <h3 class="pf-card__title">NailTechDemo</h3>
+            <p class="pf-card__row"><span class="label label--problem">Problem:</span> Manual booking process losing potential clients</p>
+            <p class="pf-card__row"><span class="label label--build">Build:</span> Sleek booking system with integrated payments</p>
+            <p class="pf-card__row"><span class="label label--outcome">Outcome:</span> Dark elegance meets functionality</p>
+            <div class="pf-card__bar"><span class="pf-card__fill"></span></div>
+          </div>
+        </article>
+
+        <!-- PhotographerDemo -->
+        <article class="pf-card" data-key="photographer" style="--bar-progress:0.86;">
+          <div class="pf-card__media" aria-hidden="true">
+            <img src="images/portfolio-photographer.jpg" alt="Professional camera and lens" loading="lazy">
+            <span class="pf-card__pill">Creative Services</span>
+            <button class="pf-card__ext" aria-label="Open PhotographerDemo case study" tabindex="-1">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3zM5 5h6v2H7v10h10v-4h2v6H5V5z"/></svg>
+            </button>
+          </div>
+          <div class="pf-card__body">
+            <h3 class="pf-card__title">PhotographerDemo</h3>
+            <p class="pf-card__row"><span class="label label--problem">Problem:</span> Cumbersome photo proofing and booking workflow</p>
+            <p class="pf-card__row"><span class="label label--build">Build:</span> Streamlined gallery with integrated booking system</p>
+            <p class="pf-card__row"><span class="label label--outcome">Outcome:</span> Creative-driven user experience</p>
+            <div class="pf-card__bar"><span class="pf-card__fill"></span></div>
+          </div>
+        </article>
+      </div>
+
+      <div class="portfolio__cta">
+        <a class="portfolio__link" href="#">View All Projects</a>
+        <div class="portfolio__cta-underline"><span class="fill"></span></div>
+      </div>
+    </div>
+  </section>
+
   <script src="./scripts/header.js" type="module"></script>
   <script src="./scripts/hero.js" type="module"></script>
   <!-- Services interactions -->
   <script src="./scripts/services.js" type="module"></script>
+  <script src="./scripts/portfolio.js" type="module"></script>
 </body>
 </html>

--- a/scripts/portfolio.js
+++ b/scripts/portfolio.js
@@ -1,0 +1,96 @@
+const section = document.querySelector('#portfolio');
+
+if (!section) {
+  // Section not present on this page; nothing to enhance.
+} else {
+  const initPortfolio = () => {
+    const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const cards = Array.from(section.querySelectorAll('.pf-card'));
+    const head = section.querySelector('.portfolio__head');
+    const cta = section.querySelector('.portfolio__cta');
+    const revealables = [head, ...cards, cta].filter(Boolean);
+
+    if (!revealables.length) {
+      return;
+    }
+
+    section.classList.add('is-enhanced');
+
+    const STAGGER = 0.08;
+    revealables.forEach((element, index) => {
+      const delay = Math.min(index * STAGGER, 0.56);
+      element.style.setProperty('--io-delay', `${delay.toFixed(2)}s`);
+    });
+
+    cards.forEach((card) => {
+      if (!card.hasAttribute('tabindex')) {
+        card.tabIndex = 0;
+      }
+      card.setAttribute('role', 'group');
+    });
+
+    const pending = new Set(revealables);
+
+    const observerOptions = {
+      root: null,
+      rootMargin: '0px 0px -12% 0px',
+      threshold: 0.35,
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+
+        const target = entry.target;
+        target.classList.add('is-inview');
+        pending.delete(target);
+        observer.unobserve(target);
+      });
+    }, observerOptions);
+
+    pending.forEach((element) => observer.observe(element));
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        observer.disconnect();
+      } else {
+        pending.forEach((element) => observer.observe(element));
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility, { passive: true });
+
+    const handleMotionChange = () => {
+      // Reserved for future motion-specific hooks; CSS currently handles the visuals.
+    };
+
+    if (typeof reduceMotionQuery.addEventListener === 'function') {
+      reduceMotionQuery.addEventListener('change', handleMotionChange);
+    } else if (typeof reduceMotionQuery.addListener === 'function') {
+      reduceMotionQuery.addListener(handleMotionChange);
+    }
+
+    const toggleHot = (card, state) => {
+      if (state) {
+        card.classList.add('is-hot');
+      } else {
+        card.classList.remove('is-hot');
+      }
+    };
+
+    cards.forEach((card) => {
+      card.addEventListener('pointerenter', () => toggleHot(card, true));
+      card.addEventListener('pointerleave', () => toggleHot(card, false));
+      card.addEventListener('pointercancel', () => toggleHot(card, false));
+
+      card.addEventListener('focusin', () => toggleHot(card, true));
+      card.addEventListener('focusout', (event) => {
+        if (!card.contains(event.relatedTarget)) {
+          toggleHot(card, false);
+        }
+      });
+    });
+  };
+
+  initPortfolio();
+}

--- a/styles/portfolio.css
+++ b/styles/portfolio.css
@@ -1,0 +1,417 @@
+/* ==================================
+   SwiftSend — Portfolio Section
+   Glass cards with gradient reveals and progress bars
+   ================================== */
+
+#portfolio {
+  position: relative;
+  padding: clamp(72px, 9vw, 104px) 0 clamp(68px, 9vw, 96px);
+  color: #f7f3ff;
+  background:
+    linear-gradient(180deg, #1f0a3a 0%, #2a0f4c 52%, #271044 100%),
+    radial-gradient(820px 560px at -12% -20%, rgba(120, 76, 202, 0.56) 0%, rgba(120, 76, 202, 0.22) 36%, transparent 72%),
+    radial-gradient(880px 620px at 112% 118%, rgba(255, 140, 64, 0.32) 0%, rgba(255, 140, 64, 0.14) 44%, transparent 78%);
+  isolation: isolate;
+  overflow: hidden;
+}
+
+#portfolio::before {
+  content: "";
+  position: absolute;
+  inset: -10%;
+  pointer-events: none;
+  z-index: 0;
+  background: linear-gradient(
+    34deg,
+    rgba(214, 60, 255, 0) 18%,
+    rgba(214, 60, 255, 0.18) 28%,
+    rgba(214, 60, 255, 0.30) 35%,
+    rgba(214, 60, 255, 0.18) 42%,
+    rgba(214, 60, 255, 0) 52%
+  );
+  filter: blur(28px) saturate(1.1);
+  mix-blend-mode: screen;
+}
+
+#portfolio::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(80% 80% at 0% 0%, rgba(8, 4, 18, 0.55) 0%, rgba(8, 4, 18, 0) 55%),
+    radial-gradient(80% 80% at 100% 100%, rgba(8, 4, 18, 0.55) 0%, rgba(8, 4, 18, 0) 55%);
+}
+
+.portfolio__inner {
+  position: relative;
+  z-index: 1;
+  width: min(1120px, calc(100% - clamp(48px, 10vw, 160px)));
+  margin-inline: auto;
+  display: grid;
+  gap: clamp(44px, 6vw, 64px);
+}
+
+.portfolio__head {
+  display: grid;
+  gap: clamp(14px, 2.6vw, 18px);
+  text-align: center;
+  justify-items: center;
+}
+
+.portfolio__title {
+  margin: 0;
+  font-size: clamp(38px, 5.5vw, 58px);
+  font-weight: 600;
+  letter-spacing: -0.022em;
+  line-height: 1.08;
+  color: #fcf7ff;
+}
+
+.portfolio__title .grad {
+  background: linear-gradient(135deg, #ff7a18 0%, #d63cff 60%, #7a5cff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.portfolio__lede {
+  margin: 0;
+  max-width: 60ch;
+  font-size: clamp(17px, 2.3vw, 20px);
+  line-height: 1.55;
+  font-weight: 400;
+  color: rgba(246, 240, 255, 0.76);
+}
+
+.portfolio__grid {
+  display: grid;
+  gap: clamp(26px, 3vw, 32px);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 720px) {
+  .portfolio__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (min-width: 1120px) {
+  .portfolio__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+/* ===== Cards ===== */
+.pf-card {
+  --ease: cubic-bezier(0.24, 0.74, 0.27, 1);
+  --card-raise: 0px;
+  --card-reveal: 0px;
+  --tint-opacity: 0.6;
+  --tint-opacity-hot: 0.72;
+  --tint-from: rgba(90, 141, 255, 0.78);
+  --tint-to: rgba(177, 102, 255, 0.78);
+  --bar-fill: linear-gradient(90deg, #5f8eff 0%, #b573ff 100%);
+
+  position: relative;
+  display: grid;
+  gap: clamp(18px, 2.6vw, 22px);
+  padding: clamp(22px, 2.4vw, 28px);
+  border-radius: 24px;
+  background: linear-gradient(155deg, rgba(52, 24, 96, 0.74), rgba(20, 10, 44, 0.62));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow:
+    0 6px 22px rgba(8, 2, 26, 0.22),
+    0 34px 68px rgba(8, 2, 26, 0.32);
+  color: inherit;
+  contain: paint;
+  isolation: isolate;
+  transform: translate3d(0, calc(var(--card-raise) + var(--card-reveal)), 0);
+  transition:
+    transform 0.55s var(--ease),
+    box-shadow 0.55s var(--ease),
+    border-color 0.55s var(--ease),
+    background 0.55s var(--ease),
+    opacity 0.55s var(--ease);
+}
+
+.pf-card > * { position: relative; z-index: 1; }
+
+.pf-card.is-hot {
+  --card-raise: -4px;
+  will-change: transform, opacity;
+  box-shadow:
+    0 10px 28px rgba(12, 4, 38, 0.26),
+    0 36px 80px rgba(12, 4, 38, 0.42);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: linear-gradient(160deg, rgba(62, 30, 120, 0.78), rgba(18, 10, 42, 0.64));
+}
+
+.pf-card.is-hot .pf-card__title { color: #ffc76a; }
+
+.pf-card__media {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  aspect-ratio: 16 / 10;
+  background: #120820;
+}
+
+.pf-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.pf-card__media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, var(--tint-from), var(--tint-to));
+  opacity: var(--tint-opacity);
+  transition: opacity 0.55s var(--ease);
+  pointer-events: none;
+}
+
+.pf-card.is-hot .pf-card__media::after { opacity: var(--tint-opacity-hot); }
+
+.pf-card__pill {
+  position: absolute;
+  top: clamp(14px, 2vw, 18px);
+  left: clamp(14px, 2vw, 18px);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: clamp(12px, 1.8vw, 13px);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 12px 24px rgba(18, 6, 42, 0.26);
+}
+
+.pf-card__ext {
+  position: absolute;
+  top: clamp(14px, 2vw, 18px);
+  right: clamp(14px, 2vw, 18px);
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  background: rgba(18, 10, 42, 0.58);
+  color: #ffffff;
+  opacity: 0;
+  transform: scale(0.96);
+  transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
+  pointer-events: none;
+}
+
+.pf-card__ext svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.pf-card.is-hot .pf-card__ext,
+.pf-card:focus-within .pf-card__ext {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.pf-card__body {
+  display: grid;
+  gap: clamp(12px, 2vw, 16px);
+}
+
+.pf-card__title {
+  margin: 0;
+  font-size: clamp(20px, 2.6vw, 22px);
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  line-height: 1.18;
+  color: #fdf8ff;
+  transition: color 0.35s var(--ease);
+}
+
+.pf-card__row {
+  margin: 0;
+  font-size: clamp(15px, 2.1vw, 17px);
+  line-height: 1.55;
+  color: rgba(247, 240, 255, 0.78);
+}
+
+.label {
+  display: inline-flex;
+  align-items: baseline;
+  font-weight: 600;
+  margin-right: 6px;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+.label--problem { background-image: linear-gradient(125deg, #ff6b6b 0%, #ff2f88 48%, #ff6b6b 100%); }
+.label--build { background-image: linear-gradient(130deg, #37d1ff 0%, #3a7bff 52%, #37d1ff 100%); }
+.label--outcome { background-image: linear-gradient(125deg, #52d98b 0%, #26c680 55%, #52d98b 100%); }
+
+.pf-card__row span + .pf-card__trend { margin-left: 6px; }
+.pf-card__trend { color: #63e299; font-size: 0.9em; }
+
+.pf-card__bar {
+  margin-top: 6px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  overflow: hidden;
+}
+
+.pf-card__fill {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: var(--bar-fill);
+  transform-origin: left;
+  transform: scaleX(var(--bar-progress, 1));
+  transition: transform 0.7s var(--ease);
+}
+
+.pf-card:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.48);
+  outline-offset: 4px;
+}
+
+/* ===== Keyed colors ===== */
+.pf-card[data-key="realtor"] {
+  --tint-from: rgba(84, 142, 255, 0.74);
+  --tint-to: rgba(161, 94, 255, 0.78);
+  --bar-fill: linear-gradient(90deg, #4f8bff 0%, #a86aff 100%);
+}
+
+.pf-card[data-key="nailtech"] {
+  --tint-from: rgba(255, 94, 150, 0.78);
+  --tint-to: rgba(214, 36, 76, 0.8);
+  --bar-fill: linear-gradient(90deg, #ff5f9b 0%, #d6244c 100%);
+}
+
+.pf-card[data-key="photographer"] {
+  --tint-from: rgba(255, 193, 78, 0.82);
+  --tint-to: rgba(255, 126, 36, 0.8);
+  --bar-fill: linear-gradient(90deg, #ffcf58 0%, #ff7a1e 100%);
+}
+
+/* ===== CTA ===== */
+.portfolio__cta {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  text-align: center;
+}
+
+.portfolio__link {
+  color: #ffffff;
+  font-size: clamp(17px, 2.2vw, 19px);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.portfolio__cta-underline {
+  width: min(240px, 100%);
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  overflow: hidden;
+}
+
+.portfolio__cta-underline .fill {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, #ff7a18 0%, #d63cff 100%);
+  transform-origin: left;
+  transform: scaleX(1);
+  transition: transform 0.6s var(--ease);
+}
+
+/* ===== Reveal states ===== */
+#portfolio.is-enhanced .portfolio__head,
+#portfolio.is-enhanced .pf-card,
+#portfolio.is-enhanced .portfolio__cta {
+  opacity: 0;
+  transform: translate3d(0, 32px, 0);
+  transition:
+    opacity 0.65s var(--ease),
+    transform 0.65s var(--ease);
+  transition-delay: var(--io-delay, 0s);
+}
+
+#portfolio.is-enhanced .pf-card {
+  transform: translate3d(0, calc(var(--card-reveal) + var(--card-raise)), 0);
+}
+
+#portfolio.is-enhanced .portfolio__head.is-inview,
+#portfolio.is-enhanced .pf-card.is-inview,
+#portfolio.is-enhanced .portfolio__cta.is-inview {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+#portfolio.is-enhanced .pf-card:not(.is-inview) {
+  --card-reveal: 36px;
+}
+
+#portfolio.is-enhanced .pf-card:not(.is-inview) .pf-card__fill {
+  transform: scaleX(0);
+}
+
+#portfolio.is-enhanced .pf-card:not(.is-inview) .pf-card__media::after {
+  opacity: 0;
+}
+
+#portfolio.is-enhanced .portfolio__cta-underline .fill {
+  transform: scaleX(0);
+}
+
+#portfolio.is-enhanced .portfolio__cta.is-inview .portfolio__cta-underline .fill {
+  transform: scaleX(1);
+}
+
+#portfolio.is-enhanced .portfolio__head.is-inview .portfolio__title,
+#portfolio.is-enhanced .portfolio__head.is-inview .portfolio__lede {
+  transition-delay: 0.05s;
+}
+
+/* ===== Utilities ===== */
+@media (max-width: 639px) {
+  .portfolio__head { text-align: left; justify-items: flex-start; }
+  .portfolio__cta { justify-items: flex-start; text-align: left; }
+  .portfolio__cta-underline { width: 200px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #portfolio.is-enhanced .portfolio__head,
+  #portfolio.is-enhanced .pf-card,
+  #portfolio.is-enhanced .portfolio__cta {
+    opacity: 1;
+    transform: none;
+    transition: none !important;
+  }
+
+  .pf-card,
+  .pf-card__media::after,
+  .pf-card__fill,
+  .portfolio__cta-underline .fill {
+    transition: none !important;
+  }
+
+  .pf-card { transform: none !important; }
+  .pf-card.is-hot { --card-raise: 0px; }
+  #portfolio.is-enhanced .pf-card:not(.is-inview) { --card-reveal: 0px; }
+  #portfolio.is-enhanced .pf-card .pf-card__media::after { opacity: var(--tint-opacity); }
+  #portfolio.is-enhanced .pf-card .pf-card__fill,
+  .pf-card__fill { transform: scaleX(var(--bar-progress, 1)) !important; }
+  #portfolio.is-enhanced .portfolio__cta-underline .fill,
+  .portfolio__cta-underline .fill { transform: scaleX(1) !important; }
+}


### PR DESCRIPTION
## Summary
- add the Work That Stands Out section with three portfolio case study cards and CTA markup
- implement portfolio-specific styling with glass cards, gradient labels, keyed tints, and reveal animations
- enhance the section with IntersectionObserver-driven reveals, hover/focus interactions, and reduced-motion support

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d43e4c89a4832fa3f2005138f66ea4