### PR TITLE
Polish portfolio interactions and visuals

### DIFF
--- a/scripts/portfolio.js
+++ b/scripts/portfolio.js
@@ -20,12 +20,15 @@
       element.style.setProperty('--io-delay', `${(index * STAGGER_STEP).toFixed(2)}s`);
     });
 
+    const FILL_BASE_DELAY = 140;
+    const FILL_STAGGER_MS = 70;
+
     cards.forEach((card, index) => {
       if (!card.hasAttribute('tabindex')) {
         card.tabIndex = 0;
       }
       card.setAttribute('role', 'group');
-      card.dataset.fillDelay = String(Math.min(index * 70, 120));
+      card.dataset.fillDelay = String(index * FILL_STAGGER_MS);
     });
 
     const pending = new Set(revealables);
@@ -43,13 +46,14 @@
           const card = target;
           if (card.classList.contains('is-filled')) return;
 
+          const delay = Number(card.dataset.fillDelay || 0);
+
           if (prefersReducedMotion()) {
             card.classList.add('is-filled');
           } else {
-            const delay = Number(card.dataset.fillDelay || 0);
             window.setTimeout(() => {
               card.classList.add('is-filled');
-            }, delay);
+            }, FILL_BASE_DELAY + delay);
           }
         }
       });
@@ -87,13 +91,18 @@
     );
 
     const toggleHot = (card, state) => {
+      if (prefersReducedMotion()) {
+        if (!state) {
+          card.classList.remove('is-hot');
+        }
+        return;
+      }
       card.classList.toggle('is-hot', state);
     };
 
     cards.forEach((card) => {
-      card.addEventListener('pointerenter', () => toggleHot(card, true));
-      card.addEventListener('pointerleave', () => toggleHot(card, false));
-      card.addEventListener('pointercancel', () => toggleHot(card, false));
+      card.addEventListener('mouseenter', () => toggleHot(card, true));
+      card.addEventListener('mouseleave', () => toggleHot(card, false));
 
       card.addEventListener('focusin', () => toggleHot(card, true));
       card.addEventListener('focusout', (event) => {
@@ -106,6 +115,7 @@
     const fillExisting = () => {
       if (!prefersReducedMotion()) return;
       cards.forEach((card) => {
+        card.classList.remove('is-hot');
         if (card.classList.contains('is-inview')) {
           card.classList.add('is-filled');
         }

--- a/styles/portfolio.css
+++ b/styles/portfolio.css
@@ -44,7 +44,7 @@
     radial-gradient(80% 80% at 100% 100%, rgba(8, 4, 18, 0.55) 0%, rgba(8, 4, 18, 0) 55%);
 }
 
-.portfolio__inner {
+#portfolio .portfolio__inner {
   position: relative;
   z-index: 1;
   width: min(1120px, calc(100% - clamp(48px, 10vw, 160px)));
@@ -53,14 +53,14 @@
   gap: clamp(44px, 6vw, 64px);
 }
 
-.portfolio__head {
+#portfolio .portfolio__head {
   display: grid;
   gap: clamp(14px, 2.6vw, 18px);
   text-align: center;
   justify-items: center;
 }
 
-.portfolio__title {
+#portfolio .portfolio__title {
   margin: 0;
   font-size: clamp(38px, 5.5vw, 58px);
   font-weight: 600;
@@ -69,14 +69,14 @@
   color: #fcf7ff;
 }
 
-.portfolio__title .grad {
+#portfolio .portfolio__title .grad {
   background: linear-gradient(135deg, #ff7a18 0%, #d63cff 60%, #7a5cff 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
 }
 
-.portfolio__lede {
+#portfolio .portfolio__lede {
   margin: 0;
   max-width: 60ch;
   font-size: clamp(17px, 2.3vw, 20px);
@@ -85,22 +85,22 @@
   color: rgba(246, 240, 255, 0.76);
 }
 
-.portfolio__grid {
+#portfolio .portfolio__grid {
   display: grid;
   gap: clamp(26px, 3vw, 32px);
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
 @media (min-width: 720px) {
-  .portfolio__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  #portfolio .portfolio__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (min-width: 1120px) {
-  .portfolio__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  #portfolio .portfolio__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
 /* ===== Cards ===== */
-.pf-card {
+#portfolio .pf-card {
   --ease: cubic-bezier(0.24, 0.74, 0.27, 1);
   --bloom-opacity: 0.65;
   --bloom-opacity-hot: 0.75;
@@ -109,17 +109,12 @@
   --tint-from: rgba(90, 141, 255, 0.78);
   --tint-to: rgba(177, 102, 255, 0.78);
   --bar-fill: linear-gradient(90deg, #5f8eff 0%, #b573ff 100%);
+  --card-radius: 24px;
 
   position: relative;
   display: grid;
-  gap: clamp(18px, 2.6vw, 22px);
-  padding: clamp(22px, 2.4vw, 28px);
-  border-radius: 24px;
-  background: linear-gradient(155deg, rgba(52, 24, 96, 0.74), rgba(20, 10, 44, 0.62));
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow:
-    0 6px 22px rgba(8, 2, 26, 0.22),
-    0 34px 68px rgba(8, 2, 26, 0.32);
+  grid-template-rows: auto 1fr;
+  background: linear-gradient(155deg, rgba(28, 18, 46, 0.85), rgba(14, 8, 26, 0.76));
   color: inherit;
   contain: paint;
   isolation: isolate;
@@ -129,9 +124,20 @@
     box-shadow 0.55s var(--ease),
     border-color 0.55s var(--ease),
     background 0.55s var(--ease);
+
+  border-radius: var(--card-radius);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow:
+    0 6px 22px rgba(8, 2, 26, 0.22),
+    0 34px 68px rgba(8, 2, 26, 0.32);
 }
 
-.pf-card::before {
+#portfolio .pf-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+#portfolio .pf-card::before {
   content: "";
   position: absolute;
   inset: -6px;
@@ -146,11 +152,11 @@
   z-index: 0;
 }
 
-.pf-card > * { position: relative; z-index: 1; }
+#portfolio .pf-card.is-inview::before {
+  opacity: var(--bloom-opacity);
+}
 
-.pf-card.is-inview::before { opacity: var(--bloom-opacity); }
-
-.pf-card.is-hot {
+#portfolio .pf-card.is-hot {
   will-change: transform, opacity;
   box-shadow:
     0 10px 28px rgba(12, 4, 38, 0.26),
@@ -158,47 +164,76 @@
   border-color: rgba(255, 255, 255, 0.2);
 }
 
-.pf-card.is-hot::before { opacity: var(--bloom-opacity-hot); }
+#portfolio .pf-card.is-hot::before {
+  opacity: var(--bloom-opacity-hot);
+}
 
-.pf-card:is(:hover, :focus-visible) {
+#portfolio .pf-card:is(:hover, :focus-visible) {
   transform: translateY(-4px);
 }
 
-.pf-card:active { transform: translateY(-2px); }
-
-.pf-card:is(:hover, :focus-visible) .pf-card__title,
-.pf-card.is-hot .pf-card__title { color: #ffc76a; }
-
-.pf-card__media {
-  position: relative;
-  border-radius: 20px;
-  overflow: hidden;
-  aspect-ratio: 16 / 10;
-  background: #120820;
+#portfolio .pf-card:active {
+  transform: translateY(-2px);
 }
 
-.pf-card__media img {
+#portfolio .pf-card:is(:hover, :focus-visible) .pf-card__title,
+#portfolio .pf-card.is-hot .pf-card__title {
+  color: #ffc76a;
+}
+
+#portfolio .pf-card__media {
   width: 100%;
-  height: 100%;
+  display: block;
+  position: relative;
+  overflow: hidden;
+  background: #120820;
+  border-top-left-radius: var(--card-radius);
+  border-top-right-radius: var(--card-radius);
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+#portfolio .pf-card__media img {
+  width: 100%;
+  height: clamp(180px, 24vw, 240px);
   object-fit: cover;
   display: block;
+  transform: none;
+  transform-origin: center;
+  transition: transform 250ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.pf-card__media::after {
+#portfolio .pf-card__media::after {
   content: "";
   position: absolute;
   inset: 0;
+  pointer-events: none;
   background: linear-gradient(140deg, var(--tint-from), var(--tint-to));
   opacity: 0;
-  transition: opacity 0.55s var(--ease);
-  pointer-events: none;
+  transition: opacity 250ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.pf-card.is-inview .pf-card__media::after { opacity: 0.65; }
+#portfolio .pf-card.is-inview .pf-card__media::after {
+  opacity: 0.5;
+}
 
-.pf-card.is-hot .pf-card__media::after { opacity: 0.75; }
+#portfolio .pf-card.is-hot .pf-card__media img {
+  will-change: transform;
+}
 
-.pf-card__pill {
+#portfolio .pf-card.is-hot .pf-card__media::after {
+  will-change: opacity;
+}
+
+#portfolio .pf-card:is(:hover, :focus-visible) .pf-card__media img {
+  transform: scale(1.02);
+}
+
+#portfolio .pf-card:is(:hover, :focus-visible) .pf-card__media::after {
+  opacity: 0.7;
+}
+
+#portfolio .pf-card__pill {
   position: absolute;
   top: clamp(14px, 2vw, 18px);
   left: clamp(14px, 2vw, 18px);
@@ -214,7 +249,7 @@
   box-shadow: 0 12px 24px rgba(18, 6, 42, 0.26);
 }
 
-.pf-card__ext {
+#portfolio .pf-card__ext {
   position: absolute;
   top: clamp(14px, 2vw, 18px);
   right: clamp(14px, 2vw, 18px);
@@ -228,27 +263,28 @@
   color: #ffffff;
   opacity: 0;
   transform: scale(0.96);
-  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease);
+  transition: opacity 220ms var(--ease), transform 220ms var(--ease);
   pointer-events: auto;
 }
 
-.pf-card__ext svg {
+#portfolio .pf-card__ext svg {
   width: 18px;
   height: 18px;
   fill: currentColor;
 }
 
-.pf-card:is(:hover, :focus-within) .pf-card__ext {
+#portfolio .pf-card:is(:hover, :focus-within) .pf-card__ext {
   opacity: 1;
   transform: scale(1);
 }
 
-.pf-card__body {
+#portfolio .pf-card__body {
   display: grid;
   gap: clamp(12px, 2vw, 16px);
+  padding: clamp(22px, 2.4vw, 28px);
 }
 
-.pf-card__title {
+#portfolio .pf-card__title {
   margin: 0;
   font-size: clamp(20px, 2.6vw, 22px);
   font-weight: 600;
@@ -258,14 +294,14 @@
   transition: color 0.35s var(--ease);
 }
 
-.pf-card__row {
+#portfolio .pf-card__row {
   margin: 0;
   font-size: clamp(15px, 2.1vw, 17px);
   line-height: 1.55;
   color: rgba(247, 240, 255, 0.78);
 }
 
-.label {
+#portfolio .label {
   display: inline-flex;
   align-items: baseline;
   font-weight: 600;
@@ -276,14 +312,28 @@
   -webkit-text-fill-color: transparent;
 }
 
-.label--problem { background-image: linear-gradient(125deg, #ff6b6b 0%, #ff2f88 48%, #ff6b6b 100%); }
-.label--build { background-image: linear-gradient(130deg, #37d1ff 0%, #3a7bff 52%, #37d1ff 100%); }
-.label--outcome { background-image: linear-gradient(125deg, #52d98b 0%, #26c680 55%, #52d98b 100%); }
+#portfolio .label--problem {
+  background-image: linear-gradient(125deg, #ff6b6b 0%, #ff2f88 48%, #ff6b6b 100%);
+}
 
-.pf-card__row span + .pf-card__trend { margin-left: 6px; }
-.pf-card__trend { color: #63e299; font-size: 0.9em; }
+#portfolio .label--build {
+  background-image: linear-gradient(130deg, #37d1ff 0%, #3a7bff 52%, #37d1ff 100%);
+}
 
-.pf-card__bar {
+#portfolio .label--outcome {
+  background-image: linear-gradient(125deg, #52d98b 0%, #26c680 55%, #52d98b 100%);
+}
+
+#portfolio .pf-card__row span + .pf-card__trend {
+  margin-left: 6px;
+}
+
+#portfolio .pf-card__trend {
+  color: #63e299;
+  font-size: 0.9em;
+}
+
+#portfolio .pf-card__bar {
   margin-top: 6px;
   height: 4px;
   border-radius: 999px;
@@ -291,41 +341,43 @@
   overflow: hidden;
 }
 
-.pf-card__fill {
+#portfolio .pf-card__fill {
   display: block;
   width: 100%;
   height: 100%;
   background: var(--bar-fill);
   transform-origin: left;
   transform: scaleX(0);
-  transition: transform 700ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: transform 1400ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.pf-card.is-filled .pf-card__fill { transform: scaleX(1); }
+#portfolio .pf-card.is-filled .pf-card__fill {
+  transform: scaleX(1);
+}
 
-.pf-card:focus-visible {
+#portfolio .pf-card:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.48);
   outline-offset: 4px;
 }
 
 /* ===== Keyed colors ===== */
-.pf-card[data-key="realtor"] {
+#portfolio .pf-card[data-key="realtor"] {
   --bloom-from: rgba(79, 139, 255, 0.68);
   --bloom-to: rgba(166, 106, 255, 0.7);
-  --tint-from: rgba(84, 142, 255, 0.78);
-  --tint-to: rgba(161, 94, 255, 0.78);
+  --tint-from: rgba(84, 142, 255, 0.76);
+  --tint-to: rgba(161, 94, 255, 0.74);
   --bar-fill: linear-gradient(90deg, #4f8bff 0%, #a86aff 100%);
 }
 
-.pf-card[data-key="nailtech"] {
+#portfolio .pf-card[data-key="nailtech"] {
   --bloom-from: rgba(255, 94, 150, 0.7);
   --bloom-to: rgba(214, 36, 76, 0.72);
-  --tint-from: rgba(255, 94, 150, 0.78);
-  --tint-to: rgba(214, 36, 76, 0.82);
+  --tint-from: rgba(255, 104, 178, 0.78);
+  --tint-to: rgba(204, 26, 62, 0.8);
   --bar-fill: linear-gradient(90deg, #ff406d 0%, #d6244c 100%);
 }
 
-.pf-card[data-key="photographer"] {
+#portfolio .pf-card[data-key="photographer"] {
   --bloom-from: rgba(255, 193, 78, 0.68);
   --bloom-to: rgba(255, 126, 36, 0.7);
   --tint-from: rgba(255, 193, 78, 0.82);
@@ -334,21 +386,21 @@
 }
 
 /* ===== CTA ===== */
-.portfolio__cta {
+#portfolio .portfolio__cta {
   display: grid;
   justify-items: center;
   gap: 14px;
   text-align: center;
 }
 
-.portfolio__link {
+#portfolio .portfolio__link {
   color: #ffffff;
   font-size: clamp(17px, 2.2vw, 19px);
   font-weight: 600;
   text-decoration: none;
 }
 
-.portfolio__cta-underline {
+#portfolio .portfolio__cta-underline {
   position: relative;
   width: min(240px, 100%);
   height: 4px;
@@ -357,17 +409,17 @@
   overflow: hidden;
 }
 
-.portfolio__cta-underline .fill {
+#portfolio .portfolio__cta-underline .fill {
   position: absolute;
   inset: 0;
   display: block;
   background: linear-gradient(90deg, #ff7a18 0%, #d63cff 100%);
   transform-origin: left;
   transform: scaleX(0);
-  transition: transform 350ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: transform 380ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.portfolio__link:is(:hover, :focus-visible) + .portfolio__cta-underline .fill {
+#portfolio .portfolio__link:is(:hover, :focus-visible) + .portfolio__cta-underline .fill {
   transform: scaleX(1);
 }
 
@@ -390,9 +442,9 @@
 
 /* ===== Utilities ===== */
 @media (max-width: 639px) {
-  .portfolio__head { text-align: left; justify-items: flex-start; }
-  .portfolio__cta { justify-items: flex-start; text-align: left; }
-  .portfolio__cta-underline { width: 200px; }
+  #portfolio .portfolio__head { text-align: left; justify-items: flex-start; }
+  #portfolio .portfolio__cta { justify-items: flex-start; text-align: left; }
+  #portfolio .portfolio__cta-underline { width: 200px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -404,22 +456,24 @@
     transition: none !important;
   }
 
-  .pf-card,
-  .pf-card__media::after,
-  .pf-card::before,
-  .pf-card__fill,
-  .portfolio__cta-underline .fill {
+  #portfolio .pf-card,
+  #portfolio .pf-card__media::after,
+  #portfolio .pf-card::before,
+  #portfolio .pf-card__fill,
+  #portfolio .portfolio__cta-underline .fill,
+  #portfolio .pf-card__media img {
     transition: none !important;
   }
 
-  .pf-card,
-  .pf-card:is(:hover, :focus-visible),
-  .pf-card:active {
+  #portfolio .pf-card,
+  #portfolio .pf-card:is(:hover, :focus-visible),
+  #portfolio .pf-card:active {
     transform: none !important;
   }
 
-  .pf-card::before,
-  .pf-card.is-inview::before { opacity: var(--bloom-opacity) !important; }
-  .pf-card__media::after { opacity: 0.65 !important; }
-  .pf-card__fill { transform: scaleX(1) !important; }
+  #portfolio .pf-card::before,
+  #portfolio .pf-card.is-inview::before { opacity: var(--bloom-opacity) !important; }
+  #portfolio .pf-card__media::after { opacity: 0.5 !important; }
+  #portfolio .pf-card__media img { transform: none !important; }
+  #portfolio .pf-card__fill { transform: scaleX(1) !important; }
 }


### PR DESCRIPTION
## Summary
- scope portfolio styles under #portfolio and refactor cards for full-bleed media, image-only tint overlays, and updated hover micro-interactions
- slow outcome bar and CTA animations while ensuring reduced-motion users see immediate, stable states
- adjust portfolio script to stagger fill timing, persist progress bars, and manage hover hot states with reduced-motion awareness

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d494d2a808832f98d9f11eff23c658