### PR TITLE
Add Labs section with animated cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <!-- Services styles (scoped, safe even before the section exists) -->
   <link rel="stylesheet" href="./styles/services.css" />
   <link rel="stylesheet" href="./styles/portfolio.css" />
+  <link rel="stylesheet" href="./styles/labs.css" />
 </head>
 <body>
   <!-- Header -->
@@ -303,10 +304,29 @@
     </div>
   </section>
 
+  <section id="labs" class="labs-section" aria-labelledby="labs-title">
+    <div class="labs-backdrop" aria-hidden="true"></div>
+    <div class="labs-orb" data-labs-orb aria-hidden="true"></div>
+    <div class="labs-inner">
+      <header class="labs-head">
+        <h2 id="labs-title" class="labs-title" data-reveal data-reveal-index="0">
+          SwiftSend <span class="labs-title-gradient">Labs</span>
+        </h2>
+        <div class="labs-subtitle" data-reveal data-reveal-index="1">
+          <p>Affordable, Personalized, Innovative</p>
+          <p>Labs = testing ground for affordable experiments clients can actually use.</p>
+        </div>
+      </header>
+
+      <ul class="labs-grid" role="list" data-labs-grid></ul>
+    </div>
+  </section>
+
   <script src="./scripts/header.js" type="module"></script>
   <script src="./scripts/hero.js" type="module"></script>
   <!-- Services interactions -->
   <script src="./scripts/services.js" type="module"></script>
   <script src="./scripts/portfolio.js" type="module"></script>
+  <script src="./scripts/labs.js" type="module"></script>
 </body>
 </html>

--- a/scripts/labs.js
+++ b/scripts/labs.js
@@ -1,0 +1,253 @@
+const labsSection = document.querySelector('#labs');
+
+if (labsSection) {
+  const isReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const desktopMedia = window.matchMedia('(min-width: 768px)');
+
+  const labsItems = [
+    {
+      id: 'swiftpay-mini',
+      title: 'SwiftPay Mini',
+      blurb: 'One-page checkout links with auto receipts.',
+      status: 'Beta',
+      accent: 'orange',
+      statusClass: 'labs-status--beta',
+      href: '#',
+      icon: `
+        <svg viewBox="0 0 32 32" aria-hidden="true">
+          <rect x="5.5" y="7.5" width="21" height="13" rx="2.6" ry="2.6"></rect>
+          <path d="M5 13.5h22"></path>
+          <path d="M10.5 17h6" stroke-linecap="round"></path>
+          <path d="M8.5 22.5h6.5" stroke-linecap="round"></path>
+        </svg>`
+    },
+    {
+      id: 'site-in-a-day',
+      title: 'Site-in-a-Day',
+      blurb: 'Flat-rate, brand-colored sites shipped fast.',
+      status: 'Live',
+      accent: 'green',
+      statusClass: 'labs-status--live',
+      href: '#',
+      icon: `
+        <svg viewBox="0 0 32 32" aria-hidden="true">
+          <rect x="5" y="6.5" width="22" height="18" rx="3" ry="3"></rect>
+          <path d="M5 12.5h22"></path>
+          <path d="M11 18.5h6" stroke-linecap="round"></path>
+          <path d="M11 22.5h10" stroke-linecap="round"></path>
+        </svg>`
+    },
+    {
+      id: 'fee-optimizer',
+      title: 'Fee Optimizer Widget',
+      blurb: '\u201cPay by Bank & save\u201d nudges + estimator.',
+      status: 'Coming Soon',
+      accent: 'cyan',
+      statusClass: 'labs-status--coming',
+      href: '#',
+      icon: `
+        <svg viewBox="0 0 32 32" aria-hidden="true">
+          <circle cx="16" cy="16" r="9"></circle>
+          <path d="M16 10v12" stroke-linecap="round"></path>
+          <path d="M12 14h8" stroke-linecap="round"></path>
+          <path d="M12 18h4" stroke-linecap="round"></path>
+        </svg>`
+    },
+    {
+      id: 'leads-autopilot',
+      title: 'Leads Autopilot',
+      blurb: 'Form \u2192 CRM \u2192 AI triage \u2192 calendar booking.',
+      status: 'Beta',
+      accent: 'purple',
+      statusClass: 'labs-status--beta',
+      href: '#',
+      icon: `
+        <svg viewBox="0 0 32 32" aria-hidden="true">
+          <path d="M8.5 9.5h15" stroke-linecap="round"></path>
+          <path d="M8.5 15.5h10" stroke-linecap="round"></path>
+          <path d="M8.5 21.5h5.5" stroke-linecap="round"></path>
+          <path d="M21 15.5 24.5 19l-3.5 3.5" stroke-linecap="round"></path>
+        </svg>`
+    },
+    {
+      id: 'doc-copilot',
+      title: 'Doc Copilot',
+      blurb: 'PDFs into Q&A bots with citations.',
+      status: 'Prototype',
+      accent: 'rose',
+      statusClass: 'labs-status--prototype',
+      href: '#',
+      icon: `
+        <svg viewBox="0 0 32 32" aria-hidden="true">
+          <path d="M11 6.5h9.5L25.5 12v13.5H11z"></path>
+          <path d="M20 6.5v6h6" stroke-linecap="round"></path>
+          <path d="M14 16.5h8" stroke-linecap="round"></path>
+          <path d="M14 20.5h5" stroke-linecap="round"></path>
+        </svg>`
+    },
+    {
+      id: 'site-health-monitor',
+      title: 'Site Health Monitor',
+      blurb: 'Uptime + Lighthouse snapshots with alerts.',
+      status: 'Beta',
+      accent: 'blueCyan',
+      statusClass: 'labs-status--beta-alt',
+      href: '#',
+      icon: `
+        <svg viewBox="0 0 32 32" aria-hidden="true">
+          <path d="M6.5 22.5 11 14.5l4 7 4.5-10 5 11" stroke-linecap="round"></path>
+          <path d="M6 25.5h20" stroke-linecap="round"></path>
+          <path d="M7.5 9.5h17" stroke-linecap="round"></path>
+        </svg>`
+    }
+  ];
+
+  const grid = labsSection.querySelector('[data-labs-grid]');
+
+  if (grid) {
+    const fragment = document.createDocumentFragment();
+
+    labsItems.forEach((item, index) => {
+      const card = document.createElement('li');
+      card.className = `labs-card labs-card--${item.accent}`;
+      card.setAttribute('role', 'article');
+      const titleId = `${item.id}-title`;
+      card.setAttribute('aria-labelledby', titleId);
+      card.dataset.reveal = '';
+      card.dataset.revealIndex = String(index + 2); // head + subtitle occupy 0/1
+
+      const statusLabel = document.createElement('span');
+      statusLabel.className = `labs-status ${item.statusClass}`;
+      statusLabel.textContent = item.status;
+      statusLabel.setAttribute('aria-label', `Status: ${item.status}`);
+
+      const iconWrap = document.createElement('div');
+      iconWrap.className = 'labs-icon';
+      iconWrap.innerHTML = item.icon;
+      iconWrap.setAttribute('aria-hidden', 'true');
+
+      const body = document.createElement('div');
+      body.className = 'labs-card-body';
+
+      const title = document.createElement('h3');
+      title.className = 'labs-card-title';
+      title.id = titleId;
+      title.textContent = item.title;
+
+      const blurb = document.createElement('p');
+      blurb.className = 'labs-card-blurb';
+      blurb.textContent = item.blurb;
+
+      const cta = document.createElement('a');
+      cta.className = 'labs-cta';
+      cta.href = item.href;
+      cta.textContent = 'Learn More';
+
+      const rail = document.createElement('div');
+      rail.className = 'labs-rail';
+      const railDot = document.createElement('span');
+      railDot.className = 'labs-rail-dot';
+      rail.appendChild(railDot);
+
+      body.append(title, blurb, cta, rail);
+
+      card.append(iconWrap, statusLabel, body);
+
+      fragment.appendChild(card);
+    });
+
+    grid.appendChild(fragment);
+  }
+
+  const revealItems = Array.from(labsSection.querySelectorAll('[data-reveal]'));
+  const seen = new WeakSet();
+
+  if (revealItems.length) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+
+        observer.unobserve(entry.target);
+        if (seen.has(entry.target)) return;
+        seen.add(entry.target);
+
+        const index = Number(entry.target.dataset.revealIndex || 0);
+        const delay = Math.min(80 + index * 20, 220);
+
+        requestAnimationFrame(() => {
+          window.setTimeout(() => {
+            entry.target.classList.add('is-in');
+          }, delay);
+        });
+      });
+    }, {
+      rootMargin: '0px 0px -10%',
+      threshold: 0.3
+    });
+
+    revealItems.forEach((item) => observer.observe(item));
+
+    const cleanup = () => observer.disconnect();
+    window.addEventListener('beforeunload', cleanup, { once: true });
+  }
+
+  const cards = Array.from(labsSection.querySelectorAll('.labs-card'));
+  cards.forEach((card) => {
+    card.addEventListener('pointerenter', () => card.classList.add('is-hovered'));
+    card.addEventListener('pointerleave', () => card.classList.remove('is-hovered'));
+    card.addEventListener('focusin', () => card.classList.add('is-hovered'));
+    card.addEventListener('focusout', () => card.classList.remove('is-hovered'));
+  });
+
+  const orb = labsSection.querySelector('[data-labs-orb]');
+  let rafId = null;
+
+  const applyParallax = () => {
+    rafId = null;
+    if (!orb) return;
+    const allowMotion = !isReducedMotion.matches && desktopMedia.matches;
+    if (!allowMotion) {
+      orb.style.transform = 'translate3d(0, 0, 0)';
+      return;
+    }
+
+    const rect = labsSection.getBoundingClientRect();
+    const viewportHeight = window.innerHeight || 1;
+    const progress = Math.min(Math.max(1 - (rect.top + rect.height * 0.5) / (viewportHeight + rect.height), -1), 1);
+    const offsetY = Math.max(Math.min(progress * 40, 34), -34);
+    const offsetX = Math.max(Math.min(progress * 18, 16), -16);
+    orb.style.transform = `translate3d(${offsetX}px, ${offsetY}px, 0)`;
+  };
+
+  const requestParallax = () => {
+    if (rafId !== null) return;
+    rafId = requestAnimationFrame(applyParallax);
+  };
+
+  const cleanupParallax = () => {
+    window.removeEventListener('scroll', requestParallax);
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+
+  const bindParallax = () => {
+    if (!orb) return;
+    cleanupParallax();
+    if (isReducedMotion.matches || !desktopMedia.matches) {
+      orb.style.transform = 'translate3d(0, 0, 0)';
+      return;
+    }
+
+    window.addEventListener('scroll', requestParallax, { passive: true });
+    requestParallax();
+  };
+
+  bindParallax();
+
+  isReducedMotion.addEventListener('change', bindParallax);
+  desktopMedia.addEventListener('change', bindParallax);
+
+  window.addEventListener('resize', requestParallax, { passive: true });
+}

--- a/styles/labs.css
+++ b/styles/labs.css
@@ -1,0 +1,505 @@
+/* ==================================
+   SwiftSend — Labs Section
+   Experiments grid with reveal + parallax orb
+   ================================== */
+
+.labs-section {
+  position: relative;
+  padding: clamp(70px, 9vw, 96px) 0 clamp(72px, 10vw, 108px);
+  overflow: hidden;
+  color: #f7f4ff;
+}
+
+.labs-backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(680px 520px at 8% 12%, rgba(127, 76, 255, 0.25) 0%, transparent 68%),
+    radial-gradient(880px 680px at 92% 80%, rgba(255, 102, 62, 0.28) 0%, rgba(255, 102, 62, 0.06) 52%, transparent 76%);
+  opacity: 0.86;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.labs-orb {
+  position: absolute;
+  width: clamp(220px, 24vw, 320px);
+  height: clamp(220px, 24vw, 320px);
+  right: max(4vw, -40px);
+  bottom: clamp(-60px, -6vw, -16px);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 112, 62, 0.55) 0%, rgba(214, 60, 255, 0.45) 42%, rgba(12, 6, 24, 0) 72%);
+  filter: blur(18px);
+  opacity: 0.8;
+  pointer-events: none;
+  z-index: 1;
+  transform: translate3d(0, 0, 0);
+  transition: opacity 0.4s ease;
+}
+
+.labs-inner {
+  position: relative;
+  z-index: 2;
+  width: min(1120px, calc(100% - clamp(48px, 9vw, 156px)));
+  margin-inline: auto;
+  display: grid;
+  gap: clamp(32px, 5vw, 44px);
+}
+
+.labs-head {
+  display: grid;
+  gap: clamp(16px, 2.6vw, 20px);
+  text-align: center;
+  justify-items: center;
+}
+
+.labs-title {
+  margin: 0;
+  font-size: clamp(38px, 5.4vw, 58px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+}
+
+.labs-title-gradient {
+  background: var(--grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.labs-subtitle {
+  display: grid;
+  gap: 6px;
+  color: rgba(246, 240, 255, 0.72);
+  font-size: clamp(17px, 2.6vw, 20px);
+  line-height: 1.55;
+  max-width: 48ch;
+}
+
+.labs-subtitle p {
+  margin: 0;
+}
+
+.labs-grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: clamp(24px, 2.8vw, 28px);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width: 768px) {
+  .labs-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .labs-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.labs-card {
+  --labs-accent-from: rgba(140, 118, 255, 0.46);
+  --labs-accent-to: rgba(140, 118, 255, 0.22);
+  --labs-icon-from: #8a7bff;
+  --labs-icon-to: #6b38f2;
+  --labs-pill-bg: rgba(138, 123, 255, 0.18);
+  --labs-pill-color: #f5edff;
+  --labs-gold: #f5d57a;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 2.4vw, 22px);
+  padding: clamp(24px, 2.8vw, 28px) clamp(26px, 3.2vw, 32px) clamp(30px, 3.4vw, 36px);
+  border-radius: var(--radius-xl);
+  background: linear-gradient(155deg, rgba(42, 20, 78, 0.78), rgba(20, 10, 44, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 10px 28px rgba(6, 1, 22, 0.34);
+  backdrop-filter: blur(var(--blur));
+  isolation: isolate;
+  contain: paint;
+  transition:
+    transform 0.35s var(--ease),
+    box-shadow 0.35s var(--ease),
+    border-color 0.35s var(--ease),
+    background 0.35s var(--ease);
+  transform: translate3d(0, 0, 0);
+}
+
+.labs-card::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: radial-gradient(120% 140% at 20% 18%, rgba(255, 255, 255, 0.12), transparent 58%),
+    radial-gradient(140% 140% at 72% 100%, rgba(10, 6, 26, 0.55) 0%, transparent 62%),
+    radial-gradient(135% 140% at 50% 10%, var(--labs-accent-from) 0%, rgba(16, 9, 32, 0) 68%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
+  filter: saturate(1.1) blur(0.4px);
+  z-index: 0;
+}
+
+.labs-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+  mix-blend-mode: screen;
+  z-index: 1;
+}
+
+.labs-card > * {
+  position: relative;
+  z-index: 2;
+}
+
+.labs-card:hover,
+.labs-card:focus-within,
+.labs-card.is-hovered {
+  transform: translate3d(0, -3px, 0) scale(1.01);
+  box-shadow: 0 18px 46px rgba(8, 2, 28, 0.42);
+}
+
+.labs-card:hover::before,
+.labs-card:focus-within::before,
+.labs-card.is-hovered::before {
+  opacity: 1;
+  transform: scale(1.01);
+}
+
+.labs-card:focus-within {
+  outline: 2px solid rgba(255, 255, 255, 0.22);
+  outline-offset: 4px;
+}
+
+.labs-icon {
+  width: clamp(54px, 5.4vw, 64px);
+  height: clamp(54px, 5.4vw, 64px);
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, var(--labs-icon-from), var(--labs-icon-to));
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.28), 0 18px 32px rgba(var(--labs-accent-rgb, 140, 118, 255), 0.46);
+}
+
+.labs-icon svg {
+  width: 26px;
+  height: 26px;
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 8px 12px rgba(0, 0, 0, 0.25));
+}
+
+.labs-status {
+  position: absolute;
+  top: clamp(18px, 2.5vw, 22px);
+  right: clamp(18px, 2.5vw, 22px);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--labs-pill-color);
+  background: var(--labs-pill-bg);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.labs-card-title {
+  margin: 0;
+  font-size: clamp(20px, 2.8vw, 24px);
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  line-height: 1.18;
+  color: #f8f5ff;
+  transition: color 0.25s var(--ease);
+}
+
+.labs-card:hover .labs-card-title,
+.labs-card:focus-within .labs-card-title,
+.labs-card.is-hovered .labs-card-title {
+  color: var(--labs-gold);
+}
+
+.labs-card-blurb {
+  margin: 0;
+  color: rgba(238, 233, 255, 0.78);
+  font-size: 0.98rem;
+  line-height: 1.52;
+}
+
+.labs-cta {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  margin-top: auto;
+  padding: 10px 0 6px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: rgba(246, 244, 255, 0.88);
+  transition: color 0.2s var(--ease), transform 0.2s var(--ease);
+}
+
+.labs-cta::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.85));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.15s var(--ease), opacity 0.15s var(--ease);
+  opacity: 0;
+}
+
+.labs-card:hover .labs-cta,
+.labs-card:focus-within .labs-cta,
+.labs-card.is-hovered .labs-cta,
+.labs-cta:hover,
+.labs-cta:focus-visible {
+  color: #ffffff;
+}
+
+.labs-card:hover .labs-cta,
+.labs-card.is-hovered .labs-cta,
+.labs-cta:hover,
+.labs-cta:focus-visible {
+  transform: translateY(-2px);
+}
+
+.labs-card:hover .labs-cta::after,
+.labs-card:focus-within .labs-cta::after,
+.labs-card.is-hovered .labs-cta::after,
+.labs-cta:focus-visible::after,
+.labs-cta:hover::after {
+  transform: scaleX(1);
+  opacity: 1;
+}
+
+.labs-cta:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.72);
+  outline-offset: 4px;
+}
+
+.labs-rail {
+  position: relative;
+  margin-top: clamp(18px, 2.4vw, 22px);
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.12));
+  overflow: hidden;
+}
+
+.labs-rail-dot {
+  position: absolute;
+  top: 50%;
+  right: clamp(18px, 2.6vw, 22px);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.45) 60%, rgba(255, 255, 255, 0) 100%);
+  transform: translate3d(0, -50%, 0);
+  box-shadow: 0 0 12px rgba(var(--labs-accent-rgb, 140, 118, 255), 0.52);
+  transition: box-shadow 0.3s var(--ease), filter 0.3s var(--ease), background 0.3s var(--ease);
+}
+
+.labs-card:hover .labs-rail,
+.labs-card:focus-within .labs-rail,
+.labs-card.is-hovered .labs-rail {
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.28));
+}
+
+.labs-card:hover .labs-rail-dot,
+.labs-card:focus-within .labs-rail-dot,
+.labs-card.is-hovered .labs-rail-dot {
+  box-shadow: 0 0 18px rgba(var(--labs-accent-rgb, 140, 118, 255), 0.8), 0 0 32px rgba(var(--labs-accent-rgb, 140, 118, 255), 0.6);
+  filter: brightness(1.08);
+}
+
+/* Accent modifiers */
+.labs-card--orange {
+  --labs-accent-rgb: 255, 138, 0;
+  --labs-accent-from: rgba(255, 138, 0, 0.46);
+  --labs-accent-to: rgba(255, 77, 77, 0.24);
+  --labs-icon-from: #ff8a00;
+  --labs-icon-to: #ff4d4d;
+  --labs-pill-bg: rgba(255, 140, 64, 0.2);
+  --labs-pill-color: #ffe8cc;
+}
+
+.labs-card--green {
+  --labs-accent-rgb: 33, 208, 122;
+  --labs-accent-from: rgba(33, 208, 122, 0.48);
+  --labs-accent-to: rgba(18, 227, 154, 0.24);
+  --labs-icon-from: #21d07a;
+  --labs-icon-to: #12e39a;
+  --labs-pill-bg: rgba(33, 208, 122, 0.22);
+  --labs-pill-color: #eafff4;
+}
+
+.labs-card--cyan {
+  --labs-accent-rgb: 18, 214, 223;
+  --labs-accent-from: rgba(18, 214, 223, 0.5);
+  --labs-accent-to: rgba(25, 113, 255, 0.28);
+  --labs-icon-from: #12d6df;
+  --labs-icon-to: #1971ff;
+  --labs-pill-bg: rgba(18, 214, 223, 0.22);
+  --labs-pill-color: #e5fbff;
+}
+
+.labs-card--purple {
+  --labs-accent-rgb: 138, 77, 255;
+  --labs-accent-from: rgba(138, 77, 255, 0.5);
+  --labs-accent-to: rgba(183, 109, 255, 0.26);
+  --labs-icon-from: #8a4dff;
+  --labs-icon-to: #b76dff;
+  --labs-pill-bg: rgba(138, 77, 255, 0.22);
+  --labs-pill-color: #f2e7ff;
+}
+
+.labs-card--rose {
+  --labs-accent-rgb: 241, 71, 163;
+  --labs-accent-from: rgba(241, 71, 163, 0.52);
+  --labs-accent-to: rgba(255, 111, 165, 0.26);
+  --labs-icon-from: #f147a3;
+  --labs-icon-to: #ff6fa5;
+  --labs-pill-bg: rgba(241, 71, 163, 0.22);
+  --labs-pill-color: #ffe5f0;
+}
+
+.labs-card--blueCyan {
+  --labs-accent-rgb: 44, 150, 255;
+  --labs-accent-from: rgba(44, 150, 255, 0.46);
+  --labs-accent-to: rgba(18, 214, 223, 0.28);
+  --labs-icon-from: #1971ff;
+  --labs-icon-to: #12d6df;
+  --labs-pill-bg: rgba(44, 150, 255, 0.22);
+  --labs-pill-color: #e3f3ff;
+}
+
+/* Status modifiers */
+.labs-status--beta {
+  background: linear-gradient(135deg, rgba(255, 138, 0, 0.24), rgba(255, 77, 77, 0.22));
+  color: #ffe6ca;
+}
+
+.labs-status--live {
+  background: linear-gradient(135deg, rgba(28, 190, 112, 0.28), rgba(18, 227, 154, 0.24));
+  color: #e3ffef;
+}
+
+.labs-status--coming {
+  background: linear-gradient(135deg, rgba(133, 105, 255, 0.26), rgba(140, 200, 255, 0.24));
+  color: #f1ecff;
+}
+
+.labs-status--prototype {
+  background: linear-gradient(135deg, rgba(225, 82, 198, 0.3), rgba(255, 111, 165, 0.24));
+  color: #ffe9f6;
+}
+
+.labs-status--beta-alt {
+  background: linear-gradient(135deg, rgba(44, 150, 255, 0.3), rgba(18, 214, 223, 0.24));
+  color: #e4f6ff;
+}
+
+.labs-card-body {
+  display: grid;
+  gap: clamp(12px, 2vw, 16px);
+  grid-auto-flow: row;
+  align-content: start;
+}
+
+.labs-card[data-reveal] {
+  will-change: transform, opacity;
+}
+
+.labs-section [data-reveal] {
+  opacity: 0;
+  transform: translate3d(0, 8px, 0);
+  transition: opacity 0.6s var(--ease), transform 0.6s var(--ease);
+}
+
+.labs-section [data-reveal].is-in {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .labs-card,
+  .labs-card::before,
+  .labs-cta,
+  .labs-rail-dot {
+    transition-duration: 0.001ms !important;
+    transition-delay: 0ms !important;
+  }
+
+  .labs-card,
+  .labs-card:hover,
+  .labs-card:focus-within,
+  .labs-card.is-hovered {
+    transform: none !important;
+  }
+
+  .labs-card::before {
+    transform: none !important;
+  }
+
+  .labs-card:hover .labs-cta,
+  .labs-card.is-hovered .labs-cta {
+    transform: none !important;
+  }
+
+  .labs-cta:hover,
+  .labs-cta:focus-visible {
+    transform: none !important;
+  }
+
+  .labs-section [data-reveal] {
+    transform: none !important;
+  }
+
+  .labs-cta::after {
+    transition: opacity 0.15s var(--ease);
+    transform: none !important;
+  }
+
+  .labs-card:hover .labs-cta::after,
+  .labs-card:focus-within .labs-cta::after,
+  .labs-card.is-hovered .labs-cta::after,
+  .labs-cta:hover::after,
+  .labs-cta:focus-visible::after {
+    opacity: 1;
+  }
+
+  .labs-orb {
+    transform: none !important;
+  }
+}
+
+@media (max-width: 767px) {
+  .labs-head {
+    text-align: left;
+    justify-items: flex-start;
+  }
+
+  .labs-orb {
+    opacity: 0.65;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add the Labs section markup and include dedicated styles and script hooks in the page shell
- style the Labs grid with glassmorphism cards, accent modifiers, CTA underline sweep, and decorative orb
- build the Labs module to render card data, manage reveal animations, hover affordances, and desktop-only parallax

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d4ee19da48832f9defdb3ef2e2dc8b