### PR TITLE
Enhance Labs CTA hover and star density

### DIFF
--- a/scripts/labs.js
+++ b/scripts/labs.js
@@ -174,6 +174,9 @@ if (labsSection) {
       'rgba(198, 144, 255, 0.32)',
       'rgba(255, 190, 150, 0.28)'
     ];
+    const baseStarRange = { min: 48, max: 72 };
+    const baseGlowRange = { min: 8, max: 12 };
+    const densityMultiplier = desktopMedia.matches ? 4 : 2;
 
     const createPoint = (className, options) => {
       const el = document.createElement('span');
@@ -197,7 +200,9 @@ if (labsSection) {
       fragment.appendChild(el);
     };
 
-    const starCount = Math.floor(randomBetween(48, 73));
+    const starMin = baseStarRange.min * densityMultiplier;
+    const starMax = baseStarRange.max * densityMultiplier;
+    const starCount = Math.floor(randomBetween(starMin, starMax + 1));
     for (let i = 0; i < starCount; i += 1) {
       const minOpacity = randomBetween(0.32, 0.52);
       const maxOpacity = Math.min(minOpacity + randomBetween(0.18, 0.32), 0.95);
@@ -206,14 +211,16 @@ if (labsSection) {
         top: randomBetween(-6, 106),
         size: randomBetween(1, 2.2),
         duration: randomBetween(2.5, 5),
-        delay: randomBetween(0, 4),
+        delay: randomBetween(0, 3),
         twinkleMin: minOpacity,
         twinkleMax: maxOpacity,
         color: starColors[Math.floor(Math.random() * starColors.length)]
       });
     }
 
-    const glowCount = Math.floor(randomBetween(8, 13));
+    const glowMin = baseGlowRange.min * densityMultiplier;
+    const glowMax = baseGlowRange.max * densityMultiplier;
+    const glowCount = Math.floor(randomBetween(glowMin, glowMax + 1));
     for (let i = 0; i < glowCount; i += 1) {
       const minOpacity = randomBetween(0.18, 0.32);
       const maxOpacity = Math.min(minOpacity + randomBetween(0.16, 0.28), 0.78);
@@ -221,8 +228,8 @@ if (labsSection) {
         left: randomBetween(-8, 108),
         top: randomBetween(-12, 112),
         size: randomBetween(3.2, 6.4),
-        duration: randomBetween(2.8, 4.8),
-        delay: randomBetween(0, 3.6),
+        duration: randomBetween(3, 5.4),
+        delay: randomBetween(0, 3),
         twinkleMin: minOpacity,
         twinkleMax: maxOpacity,
         glowColor: glowColors[Math.floor(Math.random() * glowColors.length)],

--- a/styles/labs.css
+++ b/styles/labs.css
@@ -77,7 +77,7 @@
   border-radius: 999px;
   opacity: var(--twinkle-min, 0.4);
   animation: labs-star-twinkle var(--twinkle-duration, 4s) ease-in-out var(--twinkle-delay, 0s) infinite alternate;
-  will-change: opacity;
+  will-change: opacity, transform;
   z-index: 1;
 }
 
@@ -155,6 +155,7 @@
 
 .labs-beta-button {
   --cta-bg: linear-gradient(135deg, rgba(119, 86, 255, 0.32), rgba(62, 28, 140, 0.34));
+  --labs-brand-gradient: linear-gradient(90deg, #ff8a00 0%, #d63cff 100%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -197,28 +198,32 @@
   bottom: 12px;
   height: 2px;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 142, 74, 0), rgba(255, 170, 84, 0.9), rgba(255, 207, 120, 0));
+  background: var(--labs-brand-gradient);
   transform: scaleX(0);
   transform-origin: left;
-  transition: transform 0.18s ease-in-out;
+  opacity: 0;
+  transition: transform 0.18s var(--ease), opacity 0.18s var(--ease);
 }
 
 .labs-beta-button:focus-visible {
-  outline: 2px solid rgba(255, 214, 120, 0.8);
+  outline: 2px solid rgba(255, 255, 255, 0.85);
   outline-offset: 4px;
 }
 
 .labs-beta-button:hover,
-.labs-beta-button:focus-visible {
-  --cta-bg: linear-gradient(135deg, rgba(255, 143, 74, 0.26), rgba(255, 205, 120, 0.32));
-  color: #fff8eb;
+.labs-beta-button:focus-visible,
+.labs-beta-button.is-hovered {
+  --cta-bg: var(--labs-brand-gradient);
+  color: #ffffff;
   transform: translateY(-2px);
   box-shadow: 0 20px 48px rgba(10, 2, 28, 0.5);
 }
 
 .labs-beta-button:hover::after,
-.labs-beta-button:focus-visible::after {
+.labs-beta-button:focus-visible::after,
+.labs-beta-button.is-hovered::after {
   transform: scaleX(1);
+  opacity: 1;
 }
 
 .labs-beta-button:active {
@@ -626,7 +631,8 @@
   .labs-card.is-hovered .labs-cta,
   .labs-beta-button,
   .labs-beta-button:hover,
-  .labs-beta-button:focus-visible {
+  .labs-beta-button:focus-visible,
+  .labs-beta-button.is-hovered {
     transform: none !important;
   }
 
@@ -635,7 +641,15 @@
   }
 
   .labs-beta-button::after {
-    display: none;
+    transform: none !important;
+    opacity: 0;
+    transition: opacity 0.18s var(--ease);
+  }
+
+  .labs-beta-button:hover::after,
+  .labs-beta-button:focus-visible::after,
+  .labs-beta-button.is-hovered::after {
+    opacity: 1;
   }
 
   .labs-cta:hover,


### PR DESCRIPTION
## Summary
- update the Labs beta CTA hover/focus states to use the brand orange-to-magenta gradient on the pill and underline while keeping the default appearance unchanged
- refine reduced-motion handling so the CTA underline fades in without motion while still brightening the text
- increase the Labs starfield population to 4× density on desktop (2× on mobile) with randomized timing to maintain smooth performance

## Testing
- not run (visual change)


------
https://chatgpt.com/codex/tasks/task_e_68d5511b6b14832f949e601dcf2ad7f3