### PR TITLE
Make Labs CTA underline white

### DIFF
--- a/styles/labs.css
+++ b/styles/labs.css
@@ -198,7 +198,7 @@
   bottom: 12px;
   height: 2px;
   border-radius: 999px;
-  background: var(--labs-brand-gradient);
+  background: #ffffff;
   transform: scaleX(0);
   transform-origin: left;
   opacity: 0;


### PR DESCRIPTION
## Summary
- update the Labs beta CTA underline pseudo-element to use a solid white background while preserving its animation and layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d589803c1c832fb3427de904b3de9e