### PR TITLE
Add process section styling

### DIFF
--- a/styles/process.css
+++ b/styles/process.css
@@ -1,0 +1,386 @@
+/* ==================================
+   SwiftSend — Process Section
+   Gradient timeline with animated stars & accessible states
+   ================================== */
+
+.process {
+  position: relative;
+  isolation: isolate;
+  padding: clamp(70px, 9vw, 96px) 0 clamp(68px, 10vw, 104px);
+  color: #f7f3ff;
+  background:
+    radial-gradient(120% 120% at 18% -20%, rgba(255, 122, 24, 0.26) 0%, rgba(255, 122, 24, 0) 60%),
+    radial-gradient(120% 120% at 82% 120%, rgba(214, 60, 255, 0.28) 0%, rgba(214, 60, 255, 0) 64%),
+    linear-gradient(180deg, #0d0718 0%, #180b2e 48%, #120722 100%);
+  overflow: hidden;
+}
+
+.process::before,
+.process::after {
+  content: "";
+  position: absolute;
+  inset: -20% -10%;
+  pointer-events: none;
+  z-index: 0;
+  filter: blur(0);
+}
+
+/* shimmering star field */
+.process::before {
+  background:
+    radial-gradient(2px 2px at 20% 30%, rgba(255, 255, 255, 0.55), transparent 70%),
+    radial-gradient(1.6px 1.6px at 45% 60%, rgba(253, 200, 255, 0.45), transparent 70%),
+    radial-gradient(1.8px 1.8px at 65% 18%, rgba(214, 60, 255, 0.42), transparent 65%),
+    radial-gradient(1.5px 1.5px at 84% 72%, rgba(255, 122, 24, 0.48), transparent 70%),
+    radial-gradient(1.4px 1.4px at 12% 80%, rgba(255, 255, 255, 0.38), transparent 65%);
+  opacity: 0.65;
+  animation: processStars 18s linear infinite;
+}
+
+/* faint sweep */
+.process::after {
+  background: linear-gradient(130deg, rgba(214, 60, 255, 0) 35%, rgba(214, 60, 255, 0.22) 48%, rgba(214, 60, 255, 0) 62%);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+  transform: translate3d(0, 0, 0);
+  animation: processSweep 26s linear infinite;
+}
+
+@keyframes processStars {
+  0% { transform: translate3d(0, 0, 0); }
+  50% { transform: translate3d(-12px, -6px, 0) scale(1.02); }
+  100% { transform: translate3d(0, 0, 0); }
+}
+
+@keyframes processSweep {
+  0% { transform: translate3d(-18%, -12%, 0); }
+  50% { transform: translate3d(12%, 6%, 0); }
+  100% { transform: translate3d(-18%, -12%, 0); }
+}
+
+.process__inner {
+  position: relative;
+  z-index: 1;
+  width: min(1120px, calc(100% - clamp(48px, 9vw, 160px)));
+  margin-inline: auto;
+  display: grid;
+  gap: clamp(44px, 5vw, 56px);
+}
+
+.process__intro {
+  display: grid;
+  gap: clamp(12px, 1.6vw, 16px);
+  max-width: 720px;
+}
+
+.process__eyebrow {
+  font-size: clamp(14px, 1.4vw, 16px);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(246, 240, 255, 0.62);
+}
+
+.process__title {
+  margin: 0;
+  font-size: clamp(38px, 6vw, 60px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: #fcf7ff;
+}
+
+.process__lede {
+  margin: 0;
+  font-size: clamp(17px, 2.2vw, 20px);
+  line-height: 1.55;
+  color: rgba(244, 236, 255, 0.72);
+}
+
+.process__grid {
+  display: grid;
+  gap: clamp(26px, 3vw, 32px);
+}
+
+.process__rail {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  gap: clamp(22px, 2.8vw, 28px);
+}
+
+.process__rail::before {
+  content: "";
+  position: absolute;
+  inset: 42px calc(clamp(22px, 2.4vw, 30px) + 24px);
+  height: 2px;
+  margin-block: auto;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.18), rgba(214, 60, 255, 0.65));
+  pointer-events: none;
+  z-index: 0;
+}
+
+.process-step {
+  position: relative;
+  flex: 1 1 0;
+  display: grid;
+  gap: clamp(16px, 2vw, 20px);
+  padding: clamp(28px, 3vw, 34px);
+  border-radius: var(--radius-xl, 22px);
+  background: linear-gradient(150deg, rgba(40, 22, 76, 0.8), rgba(18, 9, 38, 0.68));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 46px rgba(8, 2, 26, 0.28);
+  backdrop-filter: blur(24px);
+  color: inherit;
+  overflow: hidden;
+  transition: transform var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
+              box-shadow var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
+              border-color var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+}
+
+.process-step::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: radial-gradient(120% 120% at 20% 20%, rgba(214, 60, 255, 0.42), transparent 65%);
+  opacity: 0;
+  transition: opacity var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+}
+
+.process-step > * { position: relative; z-index: 1; }
+
+.process-step__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  align-self: flex-start;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(17, 8, 34, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: rgba(249, 243, 255, 0.84);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 13px;
+}
+
+.process-step__icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--grad);
+  display: inline-grid;
+  place-items: center;
+  color: #180b2e;
+  font-size: 18px;
+  box-shadow: 0 10px 24px rgba(214, 60, 255, 0.4);
+}
+
+.process-step__title {
+  margin: 0;
+  font-size: clamp(20px, 2.8vw, 24px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: #fefbff;
+}
+
+.process-step__copy {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.7;
+  color: rgba(244, 236, 255, 0.68);
+}
+
+.process-step__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  margin-top: auto;
+}
+
+.process-step__actions .process-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.01em;
+  background: rgba(17, 10, 30, 0.64);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: #f8f4ff;
+  box-shadow: 0 10px 26px rgba(8, 2, 26, 0.24);
+  transition: transform var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
+              box-shadow var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
+              border-color var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+}
+
+.process-btn--primary {
+  background: var(--grad);
+  border-color: transparent;
+  color: #140824;
+  box-shadow: 0 12px 34px rgba(214, 60, 255, 0.44);
+}
+
+.process-btn--ghost {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.process-step:where(:hover, :focus-within) {
+  transform: translateY(-6px);
+  box-shadow:
+    0 24px 46px rgba(8, 2, 26, 0.28),
+    0 0 30px rgba(214, 60, 255, 0.35);
+  border-color: rgba(255, 255, 255, 0.26);
+}
+
+.process-step:where(:hover, :focus-within)::after { opacity: 1; }
+
+.process-step:active {
+  transform: translateY(-2px);
+}
+
+.process-step a,
+.process-step button,
+.process-step .process-btn {
+  position: relative;
+  z-index: 1;
+}
+
+.process-step a:focus-visible,
+.process-step button:focus-visible,
+.process-step .process-btn:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(20, 8, 36, 0.5);
+}
+
+.process-step__actions .process-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(8, 2, 26, 0.3);
+}
+
+.process-step__actions .process-btn:active {
+  transform: translateY(0);
+}
+
+.process__cta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: clamp(26px, 3vw, 32px);
+  border-radius: var(--radius-lg, 16px);
+  background: rgba(20, 11, 38, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 24px 40px rgba(8, 2, 26, 0.26);
+}
+
+.process__cta-text {
+  display: grid;
+  gap: 8px;
+  max-width: 540px;
+}
+
+.process__cta-title {
+  margin: 0;
+  font-size: clamp(22px, 3vw, 28px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.process__cta-copy {
+  margin: 0;
+  color: rgba(244, 236, 255, 0.7);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.process__cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.process__cta-actions .btn {
+  border-radius: 999px;
+  padding-inline: 1.4rem;
+}
+
+.process__cta-actions .btn-primary {
+  background: var(--grad);
+  box-shadow: 0 16px 32px rgba(214, 60, 255, 0.48);
+}
+
+.process__cta-actions .btn-primary:hover {
+  box-shadow: 0 24px 38px rgba(214, 60, 255, 0.6);
+}
+
+.process__cta-actions .btn-ghost {
+  color: rgba(248, 244, 255, 0.82);
+  border-radius: 12px;
+  padding-inline: 0.9rem;
+}
+
+@media (max-width: 1023px) {
+  .process__rail { align-items: stretch; }
+}
+
+@media (max-width: 767px) {
+  .process {
+    padding: clamp(52px, 16vw, 78px) 0 clamp(58px, 15vw, 84px);
+  }
+
+  .process__rail {
+    flex-direction: column;
+  }
+
+  .process__rail::before {
+    top: calc(clamp(28px, 5vw, 34px) + 46px);
+    bottom: calc(clamp(28px, 5vw, 34px) + 46px);
+    left: calc(clamp(28px, 5vw, 34px) + 19px);
+    right: auto;
+    width: 2px;
+    height: auto;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(214, 60, 255, 0.65));
+  }
+
+  .process-step {
+    padding: clamp(24px, 6vw, 32px);
+  }
+
+  .process-step__actions { justify-content: flex-start; }
+
+  .process__cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .process,
+  .process * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .process::before,
+  .process::after {
+    animation: none;
+  }
+
+  .process-step:where(:hover, :focus-within) {
+    transform: translateY(0);
+  }
+
+  .process-step__actions .process-btn:hover,
+  .process-step__actions .process-btn:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add gradient-backed process section layout with animated starfield accents and timeline rail
- style process steps with badges, icons, focus states, and CTA buttons consistent with design tokens
- implement responsive stacking, reduced motion fallbacks, and hover/active treatments for interactive elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d591dcf1f8832fb2f2c625d25bc516