### PR TITLE
Refactor process section markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,41 +329,69 @@
     </div>
   </section>
 
-  <section id="process" class="process-section" aria-labelledby="process-title">
-    <div class="process-glow" aria-hidden="true"></div>
-    <div class="process-inner">
-      <header class="process-head">
-        <p class="process-eyebrow">Process</p>
-        <h2 id="process-title" class="process-title">How SwiftSend Ships Software</h2>
-        <p class="process-lede">Every engagement runs through a transparent playbook that keeps strategy, build, and launch tightly aligned.</p>
+  <section id="process" class="process" aria-labelledby="process-title" data-process-section data-process-reveal-step="0.08">
+    <div class="process__stars" data-process-stars data-process-star-count="72" aria-hidden="true"></div>
+    <div class="process__inner">
+      <header class="process__intro" data-process-reveal>
+        <p class="process__eyebrow">Process</p>
+        <h2 id="process-title" class="process__title">How SwiftSend Ships Software</h2>
+        <p class="process__lede">Every engagement runs through a transparent playbook that keeps strategy, build, and launch tightly aligned.</p>
       </header>
 
-      <div class="process-body">
-        <div class="process-track" role="tablist" aria-label="SwiftSend delivery process" data-process-track>
-          <button class="process-node is-active" type="button" role="tab" aria-selected="true" aria-controls="process-panel-discover" id="process-tab-discover" data-process-node="discover">
-            <span class="process-node__index">01</span>
-            <span class="process-node__label">Discover</span>
-          </button>
-          <button class="process-node" type="button" role="tab" aria-selected="false" aria-controls="process-panel-design" id="process-tab-design" data-process-node="design">
-            <span class="process-node__index">02</span>
-            <span class="process-node__label">Design</span>
-          </button>
-          <button class="process-node" type="button" role="tab" aria-selected="false" aria-controls="process-panel-build" id="process-tab-build" data-process-node="build">
-            <span class="process-node__index">03</span>
-            <span class="process-node__label">Build</span>
-          </button>
-          <button class="process-node" type="button" role="tab" aria-selected="false" aria-controls="process-panel-launch" id="process-tab-launch" data-process-node="launch">
-            <span class="process-node__index">04</span>
-            <span class="process-node__label">Launch</span>
-          </button>
-          <button class="process-node" type="button" role="tab" aria-selected="false" aria-controls="process-panel-optimize" id="process-tab-optimize" data-process-node="optimize">
-            <span class="process-node__index">05</span>
-            <span class="process-node__label">Optimize</span>
-          </button>
+      <div class="process__grid">
+        <div class="process__rail" data-process-track role="tablist" aria-label="SwiftSend delivery process">
+          <div class="process-baseline" aria-hidden="true">
+            <div class="process-baseline__fill" data-process-baseline-fill></div>
+          </div>
+          <span class="process-runner" data-process-runner aria-hidden="true"></span>
+
+          <article class="process-step is-active" data-process-step data-process-reveal>
+            <button class="process-step-button" id="process-step-discover" aria-controls="process-panel-discover" aria-current="step">
+              <span class="process-step__badge">
+                <span class="process-step__icon" aria-hidden="true">01</span>
+                Discover
+              </span>
+              <span class="process-step__title">Align on the mission</span>
+              <span class="process-step__copy">Stakeholder interviews, metrics, and constraints shape an achievable roadmap.</span>
+            </button>
+          </article>
+
+          <article class="process-step" data-process-step data-process-reveal>
+            <button class="process-step-button" id="process-step-design" aria-controls="process-panel-design">
+              <span class="process-step__badge">
+                <span class="process-step__icon" aria-hidden="true">02</span>
+                Design
+              </span>
+              <span class="process-step__title">Design the experience</span>
+              <span class="process-step__copy">Flows, prototypes, and system design make the product tangible fast.</span>
+            </button>
+          </article>
+
+          <article class="process-step" data-process-step data-process-reveal>
+            <button class="process-step-button" id="process-step-build" aria-controls="process-panel-build">
+              <span class="process-step__badge">
+                <span class="process-step__icon" aria-hidden="true">03</span>
+                Build
+              </span>
+              <span class="process-step__title">Ship in integrated sprints</span>
+              <span class="process-step__copy">Full-stack teams deliver production-ready slices with QA and automation baked in.</span>
+            </button>
+          </article>
+
+          <article class="process-step" data-process-step data-process-reveal>
+            <button class="process-step-button" id="process-step-launch" aria-controls="process-panel-launch">
+              <span class="process-step__badge">
+                <span class="process-step__icon" aria-hidden="true">04</span>
+                Launch
+              </span>
+              <span class="process-step__title">Launch &amp; optimize</span>
+              <span class="process-step__copy">We orchestrate go-live, train teams, and monitor performance to iterate quickly.</span>
+            </button>
+          </article>
         </div>
 
         <div class="process-panels" data-process-panels>
-          <article class="process-panel is-active" role="tabpanel" id="process-panel-discover" aria-labelledby="process-tab-discover" data-process-panel="discover">
+          <article class="process-panel is-active" role="tabpanel" id="process-panel-discover" aria-labelledby="process-step-discover">
             <h3 class="process-panel__title">Discover &amp; Align</h3>
             <p class="process-panel__body">Stakeholder interviews, system audits, and success metrics give us a 360° view. We scope intelligently and align the engagement around measurable outcomes.</p>
             <ul class="process-panel__list">
@@ -373,7 +401,7 @@
             </ul>
           </article>
 
-          <article class="process-panel" role="tabpanel" id="process-panel-design" aria-labelledby="process-tab-design" hidden data-process-panel="design">
+          <article class="process-panel" role="tabpanel" id="process-panel-design" aria-labelledby="process-step-design" hidden>
             <h3 class="process-panel__title">Design the Experience</h3>
             <p class="process-panel__body">We translate requirements into flows, wireframes, and interface systems that feel fast and intuitive. Content, UX, and dev collaborate in real time.</p>
             <ul class="process-panel__list">
@@ -383,7 +411,7 @@
             </ul>
           </article>
 
-          <article class="process-panel" role="tabpanel" id="process-panel-build" aria-labelledby="process-tab-build" hidden data-process-panel="build">
+          <article class="process-panel" role="tabpanel" id="process-panel-build" aria-labelledby="process-step-build" hidden>
             <h3 class="process-panel__title">Build in Sprints</h3>
             <p class="process-panel__body">Engineers ship in short sprint cycles, pairing with QA to ensure quality. Automation, data wiring, and infrastructure land together.</p>
             <ul class="process-panel__list">
@@ -393,7 +421,7 @@
             </ul>
           </article>
 
-          <article class="process-panel" role="tabpanel" id="process-panel-launch" aria-labelledby="process-tab-launch" hidden data-process-panel="launch">
+          <article class="process-panel" role="tabpanel" id="process-panel-launch" aria-labelledby="process-step-launch" hidden>
             <h3 class="process-panel__title">Launch with Confidence</h3>
             <p class="process-panel__body">We prep infrastructure, train teams, and execute the go-live plan. Performance is monitored so we can react quickly.</p>
             <ul class="process-panel__list">
@@ -402,17 +430,18 @@
               <li>Performance dashboards</li>
             </ul>
           </article>
-
-          <article class="process-panel" role="tabpanel" id="process-panel-optimize" aria-labelledby="process-tab-optimize" hidden data-process-panel="optimize">
-            <h3 class="process-panel__title">Optimize &amp; Grow</h3>
-            <p class="process-panel__body">We stay on to analyze data, run experiments, and keep the product evolving. Feedback drives the next round of improvements.</p>
-            <ul class="process-panel__list">
-              <li>Post-launch analytics &amp; insights</li>
-              <li>Experimentation pipeline</li>
-              <li>Growth + retention initiatives</li>
-            </ul>
-          </article>
         </div>
+
+        <aside class="process__cta" data-process-reveal>
+          <div class="process__cta-text">
+            <h3 class="process__cta-title">Ready to run this playbook?</h3>
+            <p class="process__cta-copy">Kick off a discovery call and we’ll map your first sprint within days.</p>
+          </div>
+          <div class="process__cta-actions">
+            <a class="btn btn-primary" href="#contact">Book a Strategy Call</a>
+            <a class="btn btn-ghost" href="#services">Explore Services</a>
+          </div>
+        </aside>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- replace the process section with the new `.process` layout that includes the star host, runner, and baseline elements expected by the updated styles and script
- wire four step buttons to their matching panels and add the CTA block so the new structure works with `process.js`

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d595a23bfc832fb393610db5f450c6