### PR TITLE
Align process intro with labs styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,9 +333,8 @@
     <div class="process__stars" data-process-stars data-process-star-count="72" aria-hidden="true"></div>
     <div class="process__inner">
       <header class="process__intro" data-process-reveal>
-        <p class="process__eyebrow">Process</p>
-        <h2 id="process-title" class="process__title">How SwiftSend Ships Software</h2>
-        <p class="process__lede">Every engagement runs through a transparent playbook that keeps strategy, build, and launch tightly aligned.</p>
+        <h2 id="process-title" class="process__title">How We <span class="grad-word">Work</span></h2>
+        <p class="process__lede">A streamlined process designed for efficiency and excellence</p>
       </header>
 
       <div class="process__grid">

--- a/styles/process.css
+++ b/styles/process.css
@@ -69,30 +69,28 @@
 
 .process__intro {
   display: grid;
-  gap: clamp(12px, 1.6vw, 16px);
+  gap: clamp(16px, 2.6vw, 20px);
   max-width: 720px;
-}
-
-.process__eyebrow {
-  font-size: clamp(14px, 1.4vw, 16px);
-  letter-spacing: 0.32em;
-  text-transform: uppercase;
-  color: rgba(246, 240, 255, 0.62);
+  text-align: center;
+  justify-items: center;
+  margin-inline: auto;
 }
 
 .process__title {
   margin: 0;
-  font-size: clamp(38px, 6vw, 60px);
+  font-size: clamp(38px, 5.4vw, 58px);
+  font-weight: 600;
   line-height: 1.05;
   letter-spacing: -0.02em;
-  color: #fcf7ff;
+  color: #ffffff;
 }
 
 .process__lede {
   margin: 0;
-  font-size: clamp(17px, 2.2vw, 20px);
+  font-size: clamp(17px, 2.6vw, 20px);
   line-height: 1.55;
   color: rgba(244, 236, 255, 0.72);
+  max-width: 48ch;
 }
 
 .process__grid {


### PR DESCRIPTION
## Summary
- update the Process section heading and copy to match the Labs gradient styling
- center the Process intro layout and align the type scale with the Labs section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ba256840832f89687ee6629043db