### PR TITLE
Revamp process starfield rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
   </section>
 
   <section id="process" class="process" aria-labelledby="process-title" data-process-section data-process-reveal-step="0.08">
-    <div class="process__stars" data-process-stars data-process-star-count="72" aria-hidden="true"></div>
+    <div class="process-stars" aria-hidden="true"></div>
     <div class="process__inner">
       <header class="process__intro" data-process-reveal>
         <h2 id="process-title" class="process__title">How We <span class="grad-word">Work</span></h2>

--- a/styles/process.css
+++ b/styles/process.css
@@ -15,7 +15,7 @@
   overflow: hidden;
 }
 
-.process::before,
+/* faint sweep */
 .process::after {
   content: "";
   position: absolute;
@@ -23,22 +23,6 @@
   pointer-events: none;
   z-index: 0;
   filter: blur(0);
-}
-
-/* shimmering star field */
-.process::before {
-  background:
-    radial-gradient(2px 2px at 20% 30%, rgba(255, 255, 255, 0.55), transparent 70%),
-    radial-gradient(1.6px 1.6px at 45% 60%, rgba(253, 200, 255, 0.45), transparent 70%),
-    radial-gradient(1.8px 1.8px at 65% 18%, rgba(214, 60, 255, 0.42), transparent 65%),
-    radial-gradient(1.5px 1.5px at 84% 72%, rgba(255, 122, 24, 0.48), transparent 70%),
-    radial-gradient(1.4px 1.4px at 12% 80%, rgba(255, 255, 255, 0.38), transparent 65%);
-  opacity: 0.65;
-  animation: processStars 18s linear infinite;
-}
-
-/* faint sweep */
-.process::after {
   background: linear-gradient(130deg, rgba(214, 60, 255, 0) 35%, rgba(214, 60, 255, 0.22) 48%, rgba(214, 60, 255, 0) 62%);
   mix-blend-mode: screen;
   opacity: 0.65;
@@ -46,10 +30,58 @@
   animation: processSweep 26s linear infinite;
 }
 
-@keyframes processStars {
-  0% { transform: translate3d(0, 0, 0); }
-  50% { transform: translate3d(-12px, -6px, 0) scale(1.02); }
-  100% { transform: translate3d(0, 0, 0); }
+.process-stars {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.process-star {
+  position: absolute;
+  inset: auto;
+  left: var(--x, 50%);
+  top: var(--y, 50%);
+  width: var(--size, 2.4px);
+  height: var(--size, 2.4px);
+  border-radius: 999px;
+  transform: translate3d(-50%, -50%, 0);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.75) 42%, rgba(214, 60, 255, 0.35) 70%, rgba(214, 60, 255, 0) 100%);
+  opacity: var(--opacity, 0.85);
+  filter: drop-shadow(0 0 calc(var(--size, 2.4px) * 2.4) rgba(214, 60, 255, 0.6));
+  pointer-events: none;
+}
+
+.process-star--glow {
+  width: var(--size, 22px);
+  height: var(--size, 22px);
+  opacity: var(--glow-opacity, 0.32);
+  background: radial-gradient(circle, rgba(214, 60, 255, 0.55) 0%, rgba(214, 60, 255, 0.24) 36%, rgba(214, 60, 255, 0.08) 58%, rgba(214, 60, 255, 0) 80%);
+  filter: blur(0) drop-shadow(0 0 calc(var(--size, 22px) * 0.7) rgba(214, 60, 255, 0.6));
+  mix-blend-mode: screen;
+}
+
+.process-star--twinkle {
+  animation: processStarTwinkle var(--twinkle-duration, 4s) ease-in-out var(--twinkle-delay, 0s) infinite;
+}
+
+@keyframes processStarTwinkle {
+  0%,
+  100% {
+    opacity: calc(var(--opacity, 0.85) * 0.35);
+    transform: translate3d(-50%, -50%, 0) scale(0.8);
+  }
+  50% {
+    opacity: calc(var(--opacity, 0.85) * 1.15);
+    transform: translate3d(-50%, -50%, 0) scale(1.15);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .process-star--twinkle {
+    animation: none;
+  }
 }
 
 @keyframes processSweep {


### PR DESCRIPTION
## Summary
- replace the process section star host markup and update associated CSS to render the decorative field behind content with gradients and twinkle animation fallbacks
- overhaul star generation to randomize star and glow counts, sizes, and animation timing while respecting reduced-motion preferences and throttling re-renders

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5baf40044832f9c8d0c04b02b5e07