### PR TITLE
Add animated bubble highlight to process timeline

### DIFF
--- a/styles/process.css
+++ b/styles/process.css
@@ -167,6 +167,66 @@
   z-index: 0;
 }
 
+.process-baseline {
+  position: absolute;
+  inset: 42px calc(clamp(22px, 2.4vw, 30px) + 24px);
+  margin-block: auto;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+  overflow: visible;
+  z-index: 0;
+}
+
+.process-baseline__fill {
+  position: absolute;
+  inset: 0;
+  width: var(--process-baseline-fill, 0px);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.55), rgba(214, 60, 255, 0.75));
+  transition: width 0.42s var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+  will-change: width;
+  z-index: 1;
+}
+
+.process-bubble {
+  --bubble-duration: 0.36s;
+  --bubble-scale: 7.5;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  pointer-events: none;
+  transform: translate3d(var(--bubble-x, 0px), 0, 0) translate(-50%, -50%) scale(1);
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.9) 0%, rgba(214, 60, 255, 0.72) 45%, rgba(214, 60, 255, 0) 78%);
+  opacity: 0;
+  mix-blend-mode: screen;
+  will-change: transform, opacity;
+  z-index: 0;
+}
+
+.process-bubble.process-bubble-emit {
+  animation: processBubbleExpand var(--bubble-duration, 0.36s) ease-out;
+}
+
+@keyframes processBubbleExpand {
+  0% {
+    transform: translate3d(var(--bubble-x, 0px), 0, 0) translate(-50%, -50%) scale(1);
+    opacity: 0.55;
+  }
+  60% {
+    opacity: 0.75;
+  }
+  100% {
+    transform: translate3d(var(--bubble-x, 0px), 0, 0) translate(-50%, -50%) scale(var(--bubble-scale, 8));
+    opacity: 0;
+  }
+}
+
 .process-step {
   position: relative;
   flex: 1 1 0;
@@ -426,6 +486,28 @@
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(214, 60, 255, 0.65));
   }
 
+  .process-baseline {
+    top: calc(clamp(28px, 5vw, 34px) + 46px);
+    bottom: calc(clamp(28px, 5vw, 34px) + 46px);
+    left: calc(clamp(28px, 5vw, 34px) + 19px);
+    right: auto;
+    width: 2px;
+    height: auto;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .process-baseline__fill {
+    width: 100%;
+    height: var(--process-baseline-fill, 0px);
+    transition: height 0.42s var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+  }
+
+  .process-bubble {
+    top: 0;
+    left: 50%;
+    transform: translate3d(0, var(--bubble-x, 0px), 0) translate(-50%, -50%) scale(1);
+  }
+
   .process-step {
     padding: clamp(24px, 6vw, 32px);
   }
@@ -435,6 +517,20 @@
   .process__cta {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  @keyframes processBubbleExpand {
+    0% {
+      transform: translate3d(0, var(--bubble-x, 0px), 0) translate(-50%, -50%) scale(1);
+      opacity: 0.55;
+    }
+    60% {
+      opacity: 0.75;
+    }
+    100% {
+      transform: translate3d(0, var(--bubble-x, 0px), 0) translate(-50%, -50%) scale(var(--bubble-scale, 8));
+      opacity: 0;
+    }
   }
 }
 
@@ -470,5 +566,25 @@
 
   .process__cta-actions .btn-ghost:is(:hover, :focus-visible)::after {
     opacity: 1;
+  }
+
+  .process-bubble {
+    animation: none;
+    transition: opacity 0.28s ease;
+    transform: translate3d(var(--bubble-x, 0px), 0, 0) translate(-50%, -50%) scale(1) !important;
+  }
+
+  .process-bubble.process-bubble-emit {
+    opacity: 0.55;
+    animation: processBubbleFade 0.28s ease-out;
+  }
+}
+
+@keyframes processBubbleFade {
+  0% {
+    opacity: 0.55;
+  }
+  100% {
+    opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- append a reusable bubble element to the process baseline and throttle its animation timing
- compute bubble positioning in setActiveStep and refresh routines so emissions follow the active step
- style the bubble pulse with reduced-motion friendly fallbacks and ensure it layers beneath controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5c11eaaa4832fa25a7f08aef8fa51