### PR TITLE
Adjust process stars visibility handling

### DIFF
--- a/styles/process.css
+++ b/styles/process.css
@@ -66,6 +66,10 @@
   animation: processStarTwinkle var(--twinkle-duration, 4s) ease-in-out var(--twinkle-delay, 0s) infinite;
 }
 
+.process:not(.is-visible) .process-star--twinkle {
+  animation-play-state: paused;
+}
+
 @keyframes processStarTwinkle {
   0%,
   100% {


### PR DESCRIPTION
## Summary
- update desktop and mobile star/glow generation counts to new targets
- add a visibility observer on the process section to pause twinkling when offscreen
- ensure observer cleanup and reduced-motion handling remain intact via CSS controls

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5ca4e5960832f83dc305b3ccd8ff3