### PR TITLE
Revamp process detail card and interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,178 +329,100 @@
     </div>
   </section>
 
-  <section id="process" class="process" aria-labelledby="process-title" data-process-section data-process-reveal-step="0.08">
+  <section id="process" class="process" aria-labelledby="process-title" data-process-section>
     <div class="process-stars" aria-hidden="true"></div>
     <div class="process__inner">
-      <header class="process__intro" data-process-reveal>
+      <header class="process__intro" data-reveal>
         <h2 id="process-title" class="process__title">How We <span class="grad-word">Work</span></h2>
         <p class="process__lede">A streamlined process designed for efficiency and excellence</p>
       </header>
 
       <div class="process__grid">
-        <div class="process__rail" data-process-track role="tablist" aria-label="SwiftSend delivery process">
+        <div class="process__rail" data-reveal data-process-track role="tablist" aria-label="SwiftSend delivery process">
           <div class="process-baseline" aria-hidden="true">
             <div class="process-baseline__fill" data-process-baseline-fill></div>
           </div>
           <span class="process-runner" data-process-runner aria-hidden="true"></span>
 
-          <article class="process-step is-active" data-process-step data-process-reveal>
-            <button class="process-step-button" id="process-step-discover" aria-controls="process-panel-discover" aria-current="step">
-              <span class="process-step__badge">
-                <span class="process-step__icon" aria-hidden="true">01</span>
-                Discover
-              </span>
-              <span class="process-step__title">Align on the mission</span>
-              <span class="process-step__copy">Stakeholder interviews, metrics, and constraints shape an achievable roadmap.</span>
-            </button>
-          </article>
-
-          <article class="process-step" data-process-step data-process-reveal>
-            <button class="process-step-button" id="process-step-design" aria-controls="process-panel-design">
-              <span class="process-step__badge">
-                <span class="process-step__icon" aria-hidden="true">02</span>
-                Design
-              </span>
-              <span class="process-step__title">Design the experience</span>
-              <span class="process-step__copy">Flows, prototypes, and system design make the product tangible fast.</span>
-            </button>
-          </article>
-
-          <article class="process-step" data-process-step data-process-reveal>
-            <button class="process-step-button" id="process-step-build" aria-controls="process-panel-build">
-              <span class="process-step__badge">
-                <span class="process-step__icon" aria-hidden="true">03</span>
-                Build
-              </span>
-              <span class="process-step__title">Ship in integrated sprints</span>
-              <span class="process-step__copy">Full-stack teams deliver production-ready slices with QA and automation baked in.</span>
-            </button>
-          </article>
-
-          <article class="process-step" data-process-step data-process-reveal>
-            <button class="process-step-button" id="process-step-launch" aria-controls="process-panel-launch">
-              <span class="process-step__badge">
-                <span class="process-step__icon" aria-hidden="true">04</span>
-                Launch
-              </span>
-              <span class="process-step__title">Launch &amp; optimize</span>
-              <span class="process-step__copy">We orchestrate go-live, train teams, and monitor performance to iterate quickly.</span>
-            </button>
-          </article>
-        </div>
-
-        <div class="process-detail">
-          <div class="process-accordion">
-            <article class="process-accordion-item is-active" data-process-accordion-item>
-              <h3 class="process-accordion-heading">
-                <button class="process-accordion-trigger" id="process-accordion-discover" aria-controls="process-panel-discover" aria-expanded="true" type="button">
-                  <span class="process-accordion-badge" aria-hidden="true">
-                    <span class="process-accordion-number">01</span>
-                  </span>
-                  <span class="process-accordion-icon" aria-hidden="true">
-                    <svg viewBox="0 0 32 32" role="img" aria-hidden="true">
-                      <path d="M16 28c6.627 0 12-5.373 12-12S22.627 4 16 4 4 9.373 4 16s5.373 12 12 12Z" fill="none" stroke="currentColor" stroke-width="2"></path>
-                      <path d="M11.5 14.5c0-2.485 2.015-4.5 4.5-4.5s4.5 2.015 4.5 4.5-2.015 4.5-4.5 4.5c-.904 0-1.75-.267-2.455-.724L9 23" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                    </svg>
-                  </span>
-                  <span class="process-accordion-title">Discover &amp; Align</span>
-                </button>
-              </h3>
-              <div class="process-panel process-accordion-panel is-active" role="tabpanel" id="process-panel-discover" aria-labelledby="process-accordion-discover">
-                <h4 class="process-panel__title">Discover &amp; Align</h4>
-                <p class="process-panel__body">Stakeholder interviews, system audits, and success metrics give us a 360° view. We scope intelligently and align the engagement around measurable outcomes.</p>
-                <ul class="process-panel__list">
-                  <li>Business goals + constraints mapping</li>
-                  <li>Technical + data audit</li>
-                  <li>Roadmap + estimate buy-in</li>
-                </ul>
-              </div>
+          <div class="process-steps" data-process-steps>
+            <article class="process-step process-step--discover is-active" data-process-step data-step-slug="discover" data-reveal>
+              <button class="process-step-button" id="process-step-discover" aria-controls="process-detail-card" aria-current="step" type="button">
+                <span class="process-step__badge">
+                  <span class="process-step__badge-num" aria-hidden="true">01</span>
+                  <span class="process-step__badge-label">Discover</span>
+                </span>
+                <span class="process-step__title">Align on the mission</span>
+                <span class="process-step__copy">Stakeholder interviews, metrics, and constraints shape an achievable roadmap.</span>
+              </button>
             </article>
 
-            <article class="process-accordion-item" data-process-accordion-item>
-              <h3 class="process-accordion-heading">
-                <button class="process-accordion-trigger" id="process-accordion-design" aria-controls="process-panel-design" aria-expanded="false" type="button">
-                  <span class="process-accordion-badge" aria-hidden="true">
-                    <span class="process-accordion-number">02</span>
-                  </span>
-                  <span class="process-accordion-icon" aria-hidden="true">
-                    <svg viewBox="0 0 32 32" role="img" aria-hidden="true">
-                      <path d="M7 25.5 25.5 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
-                      <path d="M22.5 9.5 25.5 7l2.5 2.5-3 3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                      <path d="M7 25.5v-4l8-8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                      <path d="M11 21.5h-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
-                    </svg>
-                  </span>
-                  <span class="process-accordion-title">Design the Experience</span>
-                </button>
-              </h3>
-              <div class="process-panel process-accordion-panel" role="tabpanel" id="process-panel-design" aria-labelledby="process-accordion-design" hidden>
-                <h4 class="process-panel__title">Design the Experience</h4>
-                <p class="process-panel__body">We translate requirements into flows, wireframes, and interface systems that feel fast and intuitive. Content, UX, and dev collaborate in real time.</p>
-                <ul class="process-panel__list">
-                  <li>Service blueprints &amp; user journeys</li>
-                  <li>Interactive prototypes</li>
-                  <li>Feedback loops with stakeholders</li>
-                </ul>
-              </div>
+            <article class="process-step process-step--design" data-process-step data-step-slug="design" data-reveal>
+              <button class="process-step-button" id="process-step-design" aria-controls="process-detail-card" type="button">
+                <span class="process-step__badge">
+                  <span class="process-step__badge-num" aria-hidden="true">02</span>
+                  <span class="process-step__badge-label">Design</span>
+                </span>
+                <span class="process-step__title">Design the experience</span>
+                <span class="process-step__copy">Flows, prototypes, and system design make the product tangible fast.</span>
+              </button>
             </article>
 
-            <article class="process-accordion-item" data-process-accordion-item>
-              <h3 class="process-accordion-heading">
-                <button class="process-accordion-trigger" id="process-accordion-build" aria-controls="process-panel-build" aria-expanded="false" type="button">
-                  <span class="process-accordion-badge" aria-hidden="true">
-                    <span class="process-accordion-number">03</span>
-                  </span>
-                  <span class="process-accordion-icon" aria-hidden="true">
-                    <svg viewBox="0 0 32 32" role="img" aria-hidden="true">
-                      <path d="M6 21h12l4 4h4v-6l-6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                      <path d="M20 7a4 4 0 1 0-6 3.465V17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                    </svg>
-                  </span>
-                  <span class="process-accordion-title">Build in Sprints</span>
-                </button>
-              </h3>
-              <div class="process-panel process-accordion-panel" role="tabpanel" id="process-panel-build" aria-labelledby="process-accordion-build" hidden>
-                <h4 class="process-panel__title">Build in Sprints</h4>
-                <p class="process-panel__body">Engineers ship in short sprint cycles, pairing with QA to ensure quality. Automation, data wiring, and infrastructure land together.</p>
-                <ul class="process-panel__list">
-                  <li>Agile sprints with demo-ready drops</li>
-                  <li>Automated testing &amp; observability</li>
-                  <li>Integrated data + AI layers</li>
-                </ul>
-              </div>
+            <article class="process-step process-step--build" data-process-step data-step-slug="build" data-reveal>
+              <button class="process-step-button" id="process-step-build" aria-controls="process-detail-card" type="button">
+                <span class="process-step__badge">
+                  <span class="process-step__badge-num" aria-hidden="true">03</span>
+                  <span class="process-step__badge-label">Build</span>
+                </span>
+                <span class="process-step__title">Ship in integrated sprints</span>
+                <span class="process-step__copy">Full-stack teams deliver production-ready slices with QA and automation baked in.</span>
+              </button>
             </article>
 
-            <article class="process-accordion-item" data-process-accordion-item>
-              <h3 class="process-accordion-heading">
-                <button class="process-accordion-trigger" id="process-accordion-launch" aria-controls="process-panel-launch" aria-expanded="false" type="button">
-                  <span class="process-accordion-badge" aria-hidden="true">
-                    <span class="process-accordion-number">04</span>
-                  </span>
-                  <span class="process-accordion-icon" aria-hidden="true">
-                    <svg viewBox="0 0 32 32" role="img" aria-hidden="true">
-                      <path d="M6 21.5s3-1 10-1 10 1 10 1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
-                      <path d="M16 5l3 6h-6l3-6Zm0 16v6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                      <path d="M10 15c1.333-1.333 3-2 6-2s4.667.667 6 2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
-                    </svg>
-                  </span>
-                  <span class="process-accordion-title">Launch with Confidence</span>
-                </button>
-              </h3>
-              <div class="process-panel process-accordion-panel" role="tabpanel" id="process-panel-launch" aria-labelledby="process-accordion-launch" hidden>
-                <h4 class="process-panel__title">Launch with Confidence</h4>
-                <p class="process-panel__body">We prep infrastructure, train teams, and execute the go-live plan. Performance is monitored so we can react quickly.</p>
-                <ul class="process-panel__list">
-                  <li>Playbooks for deployment &amp; rollback</li>
-                  <li>Support + training sessions</li>
-                  <li>Performance dashboards</li>
-                </ul>
-              </div>
+            <article class="process-step process-step--launch" data-process-step data-step-slug="launch" data-reveal>
+              <button class="process-step-button" id="process-step-launch" aria-controls="process-detail-card" type="button">
+                <span class="process-step__badge">
+                  <span class="process-step__badge-num" aria-hidden="true">04</span>
+                  <span class="process-step__badge-label">Launch</span>
+                </span>
+                <span class="process-step__title">Launch &amp; optimize</span>
+                <span class="process-step__copy">We orchestrate go-live, train teams, and monitor performance to iterate quickly.</span>
+              </button>
             </article>
           </div>
         </div>
 
-        <aside class="process__cta" data-process-reveal>
+        <div class="process-detail">
+          <div
+            class="process-detail-card is-discover"
+            id="process-detail-card"
+            data-reveal
+            data-process-detail
+            role="region"
+            aria-live="polite"
+            aria-labelledby="process-detail-title"
+          >
+            <div class="process-detail-header">
+              <span class="process-badge">
+                <span class="process-badge-num">01</span>
+                <span class="process-badge-label">DISCOVER</span>
+              </span>
+            </div>
+
+            <h3 id="process-detail-title" class="process-detail-title">Align on the mission</h3>
+
+            <p class="process-detail-body">
+              Stakeholder interviews, metrics, and constraints shape an achievable roadmap.
+            </p>
+
+            <ul class="process-detail-list">
+              <li>Business goals + constraints mapping</li>
+              <li>Technical + data audit</li>
+              <li>Roadmap + estimate buy-in</li>
+            </ul>
+          </div>
+        </div>
+
+        <aside class="process__cta" data-reveal>
           <div class="process__cta-text">
             <h3 class="process__cta-title">Ready to run this playbook?</h3>
             <p class="process__cta-copy">Kick off a discovery call and we’ll map your first sprint within days.</p>

--- a/scripts/process.js
+++ b/scripts/process.js
@@ -1,4 +1,70 @@
 (function () {
+  const PROCESS_DATA = {
+    discover: {
+      num: '01',
+      label: 'DISCOVER',
+      title: 'Align on the mission',
+      copy: 'Stakeholder interviews, metrics, and constraints shape an achievable roadmap.',
+      body: 'Stakeholder interviews, metrics, and constraints shape an achievable roadmap.',
+      bullets: [
+        'Business goals + constraints mapping',
+        'Technical + data audit',
+        'Roadmap + estimate buy-in',
+      ],
+      accent: 'discover',
+      accentRgb: '45, 139, 255',
+      accentRgbAlt: '29, 229, 255',
+    },
+    design: {
+      num: '02',
+      label: 'DESIGN',
+      title: 'Design the experience',
+      copy: 'Flows, prototypes, and system design make the product tangible fast.',
+      body: 'Flows, prototypes, and system design make the product tangible fast.',
+      bullets: [
+        'UX flows + prototypes',
+        'System design & API contracts',
+        'Feasibility + fast iterations',
+      ],
+      accent: 'design',
+      accentRgb: '162, 72, 255',
+      accentRgbAlt: '255, 100, 242',
+    },
+    build: {
+      num: '03',
+      label: 'BUILD',
+      title: 'Ship in integrated sprints',
+      copy: 'Full-stack teams deliver production-ready slices with QA and automation baked in.',
+      body: 'Full-stack teams deliver production-ready slices with QA and automation baked in.',
+      bullets: [
+        'Sprint slices to prod',
+        'Automated testing & CI',
+        'Observability from day one',
+      ],
+      accent: 'build',
+      accentRgb: '255, 138, 60',
+      accentRgbAlt: '255, 69, 84',
+    },
+    launch: {
+      num: '04',
+      label: 'LAUNCH',
+      title: 'Launch & optimize',
+      copy: 'We orchestrate go-live, train teams, and monitor performance to iterate quickly.',
+      body: 'We orchestrate go-live, train teams, and monitor performance to iterate quickly.',
+      bullets: [
+        'Go-live & training',
+        'KPIs & dashboards',
+        'Continuous optimization',
+      ],
+      accent: 'launch',
+      accentRgb: '68, 242, 141',
+      accentRgbAlt: '30, 203, 121',
+    },
+  };
+
+  const STAGGER_STEP = 0.08;
+  const ACCENT_CLASSES = Object.keys(PROCESS_DATA).map((slug) => `is-${slug}`);
+
   const initProcess = () => {
     const section = document.getElementById('process') || document.querySelector('[data-process-section]');
     if (!section) return;
@@ -13,18 +79,18 @@
     const randomIntInRange = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
     const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
+    const isCompactViewport = () => {
+      const viewportWidth = window.innerWidth || document.documentElement.clientWidth || section.clientWidth || 0;
+      return viewportWidth < 768;
+    };
+
     const starsHost = section.querySelector('.process-stars');
     let starsRenderPending = false;
     let pendingForceStars = false;
     let lastStarsConfigKey = '';
-    const toggleSectionVisibility = (isVisible) => {
-      section.classList.toggle('is-visible', Boolean(isVisible));
-    };
-    let sectionVisibilityObserver;
 
     const renderStars = (force = false) => {
       if (!starsHost) return;
-
       const viewportWidth = window.innerWidth || document.documentElement.clientWidth || section.clientWidth || 0;
       const isCompact = viewportWidth < 768;
       const reducedMotion = prefersReducedMotion();
@@ -48,14 +114,14 @@
         star.className = 'process-star';
         star.style.setProperty('--x', `${randomInRange(0, 100).toFixed(2)}%`);
         star.style.setProperty('--y', `${randomInRange(0, 100).toFixed(2)}%`);
-        const size = randomInRange(1.4, 3.4);
+        const size = randomInRange(1.2, 3);
         star.style.setProperty('--size', `${size.toFixed(2)}px`);
-        const opacity = randomInRange(0.42, 0.95);
+        const opacity = randomInRange(0.4, 0.9);
         star.style.setProperty('--opacity', opacity.toFixed(2));
 
-        if (shouldAnimate && Math.random() > 0.28) {
+        if (shouldAnimate && Math.random() > 0.32) {
           star.classList.add('process-star--twinkle');
-          star.style.setProperty('--twinkle-duration', `${randomInRange(2.5, 5).toFixed(2)}s`);
+          star.style.setProperty('--twinkle-duration', `${randomInRange(2.6, 5).toFixed(2)}s`);
           star.style.setProperty('--twinkle-delay', `${randomInRange(0, 5).toFixed(2)}s`);
         }
 
@@ -67,16 +133,16 @@
         glow.className = 'process-star process-star--glow';
         glow.style.setProperty('--x', `${randomInRange(0, 100).toFixed(2)}%`);
         glow.style.setProperty('--y', `${randomInRange(0, 100).toFixed(2)}%`);
-        const size = randomInRange(16, 34);
-        const opacity = randomInRange(0.22, 0.48);
+        const size = isCompact ? randomInRange(10, 16) : randomInRange(18, 26);
+        const opacity = isCompact ? randomInRange(0.16, 0.32) : randomInRange(0.2, 0.42);
         glow.style.setProperty('--size', `${size.toFixed(2)}px`);
         glow.style.setProperty('--glow-opacity', opacity.toFixed(2));
         glow.style.setProperty('--opacity', opacity.toFixed(2));
 
         if (shouldAnimate && Math.random() > 0.45) {
           glow.classList.add('process-star--twinkle');
-          glow.style.setProperty('--twinkle-duration', `${randomInRange(2.5, 5).toFixed(2)}s`);
-          glow.style.setProperty('--twinkle-delay', `${randomInRange(0, 5).toFixed(2)}s`);
+          glow.style.setProperty('--twinkle-duration', `${randomInRange(2.8, 5.4).toFixed(2)}s`);
+          glow.style.setProperty('--twinkle-delay', `${randomInRange(0, 4.2).toFixed(2)}s`);
         }
 
         fragment.appendChild(glow);
@@ -102,6 +168,10 @@
       scheduleStarRender({ force: true });
     }
 
+    const toggleSectionVisibility = (isVisible) => {
+      section.classList.toggle('is-visible', Boolean(isVisible));
+    };
+
     const computeInitialVisibility = () => {
       const rect = section.getBoundingClientRect();
       const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
@@ -109,6 +179,7 @@
       return rect.bottom > 0 && rect.right > 0 && rect.top < viewportHeight && rect.left < viewportWidth;
     };
 
+    let sectionVisibilityObserver;
     if (typeof IntersectionObserver === 'function') {
       sectionVisibilityObserver = new IntersectionObserver(
         (entries) => {
@@ -117,9 +188,7 @@
             toggleSectionVisibility(entry.isIntersecting);
           });
         },
-        {
-          threshold: 0.2,
-        }
+        { threshold: 0.2 }
       );
       sectionVisibilityObserver.observe(section);
       toggleSectionVisibility(computeInitialVisibility());
@@ -127,274 +196,69 @@
       toggleSectionVisibility(true);
     }
 
-    const stepData = new Map([
-      [
-        'discover',
-        {
-          number: '01',
-          label: 'Discover & Align',
-          title: 'Align on the mission',
-          body:
-            'Stakeholder interviews, system audits, and success metrics give us a 360° view. We scope intelligently and align the engagement around measurable outcomes.',
-          copy: 'Stakeholder interviews, metrics, and constraints shape an achievable roadmap.',
-          bullets: [
-            'Business goals + constraints mapping',
-            'Technical + data audit',
-            'Roadmap + estimate buy-in',
-          ],
-          accent: 'discover',
-          badge: 'Discover',
-        },
-      ],
-      [
-        'design',
-        {
-          number: '02',
-          label: 'Design the Experience',
-          title: 'Design the experience',
-          body:
-            'We translate requirements into flows, wireframes, and interface systems that feel fast and intuitive. Content, UX, and dev collaborate in real time.',
-          copy: 'Flows, prototypes, and system design make the product tangible fast.',
-          bullets: [
-            'Service blueprints & user journeys',
-            'Interactive prototypes',
-            'Feedback loops with stakeholders',
-          ],
-          accent: 'design',
-          badge: 'Design',
-        },
-      ],
-      [
-        'build',
-        {
-          number: '03',
-          label: 'Build in Sprints',
-          title: 'Ship in integrated sprints',
-          body:
-            'Engineers ship in short sprint cycles, pairing with QA to ensure quality. Automation, data wiring, and infrastructure land together.',
-          copy: 'Full-stack teams deliver production-ready slices with QA and automation baked in.',
-          bullets: [
-            'Agile sprints with demo-ready drops',
-            'Automated testing & observability',
-            'Integrated data + AI layers',
-          ],
-          accent: 'build',
-          badge: 'Build',
-        },
-      ],
-      [
-        'launch',
-        {
-          number: '04',
-          label: 'Launch with Confidence',
-          title: 'Launch & optimize',
-          body:
-            'We prep infrastructure, train teams, and execute the go-live plan. Performance is monitored so we can react quickly.',
-          copy: 'We orchestrate go-live, train teams, and monitor performance to iterate quickly.',
-          bullets: [
-            'Playbooks for deployment & rollback',
-            'Support + training sessions',
-            'Performance dashboards',
-          ],
-          accent: 'launch',
-          badge: 'Launch',
-        },
-      ],
-    ]);
-
-    const isCompactViewport = () => {
-      const viewportWidth = window.innerWidth || document.documentElement.clientWidth || section.clientWidth || 0;
-      return viewportWidth < 768;
-    };
-
-    const revealables = Array.from(section.querySelectorAll('[data-process-reveal]'));
-    const revealDelayStep = Number(section.getAttribute('data-process-reveal-step') || 0.09);
-
-    revealables.forEach((element, index) => {
-      element.style.setProperty('--process-reveal-delay', `${(index * revealDelayStep).toFixed(2)}s`);
+    const revealTargets = Array.from(section.querySelectorAll('[data-reveal]'));
+    revealTargets.forEach((target, index) => {
+      target.style.setProperty('--process-reveal-delay', `${(index * STAGGER_STEP).toFixed(2)}s`);
+      if (section.classList.contains('has-seen')) {
+        target.classList.add('is-in');
+      }
     });
 
-    let revealObserver;
-    if (revealables.length) {
-      const pending = new Set(revealables);
-      const handleIntersection = (entries) => {
-        entries.forEach((entry) => {
-          if (!entry.isIntersecting) return;
-          const target = entry.target;
-          target.classList.add('is-visible');
-          pending.delete(target);
-          revealObserver.unobserve(target);
-        });
-        if (!pending.size) {
-          revealObserver.disconnect();
-        }
-      };
-
-      revealObserver = new IntersectionObserver(handleIntersection, {
-        root: null,
-        rootMargin: '0px 0px -12% 0px',
-        threshold: 0.35,
-      });
-
-      revealables.forEach((element) => revealObserver.observe(element));
-    }
-
-    const steps = Array.from(section.querySelectorAll('.process-step-button'));
-    if (!steps.length) {
-      if (revealObserver) revealObserver.disconnect();
+    const stepArticles = Array.from(section.querySelectorAll('[data-process-step]'));
+    const buttons = stepArticles.map((article) => article.querySelector('.process-step-button')).filter(Boolean);
+    if (!buttons.length) {
+      if (controller) controller.abort();
+      if (sectionVisibilityObserver) sectionVisibilityObserver.disconnect();
       return;
     }
 
-    const detail = section.querySelector('.process-detail');
-    if (detail && !detail.hasAttribute('aria-live')) {
-      detail.setAttribute('aria-live', 'polite');
-    }
-
-    const stepSlugs = steps.map((button, index) => {
-      const identifier = button.id || '';
-      const match = identifier.match(/process-step-(.+)/);
-      return match ? match[1] : `step-${index}`;
+    const slugForIndex = stepArticles.map((article, index) => {
+      const slugAttr = article.getAttribute('data-step-slug');
+      if (slugAttr && PROCESS_DATA[slugAttr]) {
+        return slugAttr;
+      }
+      const button = buttons[index];
+      if (button && button.id) {
+        const match = button.id.match(/process-step-(.+)/);
+        if (match && PROCESS_DATA[match[1]]) {
+          return match[1];
+        }
+      }
+      const fallback = Object.keys(PROCESS_DATA)[index];
+      return fallback || Object.keys(PROCESS_DATA)[0];
     });
 
-    const slugToIndex = new Map();
-    stepSlugs.forEach((slug, index) => {
-      if (!slugToIndex.has(slug)) {
-        slugToIndex.set(slug, index);
-      }
-    });
-
-    const detailAccentModifiers = Array.from(
-      new Set(
-        Array.from(stepData.values())
-          .map((entry) => (entry && entry.accent ? `is-${entry.accent}` : null))
-          .filter(Boolean)
-      )
-    );
-
-    const accordionEntries = stepSlugs.map((slug) => {
-      if (!slug) {
-        return { slug: '', trigger: null, panel: null, item: null };
-      }
-      const trigger = detail ? detail.querySelector(`#process-accordion-${slug}`) : null;
-      const panelId = trigger ? trigger.getAttribute('aria-controls') : null;
-      const panel = panelId ? document.getElementById(panelId) : null;
-      const item = trigger ? trigger.closest('[data-process-accordion-item], .process-accordion-item') : null;
-      return { slug, trigger, panel, item };
-    });
-
-    const accordionBySlug = new Map();
-    accordionEntries.forEach((entry) => {
-      if (!entry || !entry.slug) return;
-      accordionBySlug.set(entry.slug, entry);
-      if (entry.trigger) {
-        const expanded = entry.item ? entry.item.classList.contains('is-active') : false;
-        entry.trigger.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-      }
-    });
-
-    const populateStepContent = (slug, button) => {
-      if (!button) return;
-      const data = stepData.get(slug);
-      if (!data) return;
-
-      const badge = button.querySelector('.process-step__badge');
-      if (badge) {
-        badge.innerHTML = '';
-        const icon = document.createElement('span');
-        icon.className = 'process-step__icon';
-        icon.setAttribute('aria-hidden', 'true');
-        icon.textContent = data.number || '';
-        badge.appendChild(icon);
-        badge.appendChild(document.createTextNode(` ${data.badge || data.label || ''}`));
-      }
-
+    stepArticles.forEach((article, index) => {
+      const slug = slugForIndex[index];
+      const button = buttons[index];
+      const data = PROCESS_DATA[slug];
+      if (!data || !button) return;
+      article.classList.add(`process-step--${slug}`);
+      const badgeNum = button.querySelector('.process-step__badge-num');
+      if (badgeNum) badgeNum.textContent = data.num || '';
+      const badgeLabel = button.querySelector('.process-step__badge-label');
+      if (badgeLabel) badgeLabel.textContent = (data.label || '').toString();
       const titleEl = button.querySelector('.process-step__title');
-      if (titleEl && data.title) {
-        titleEl.textContent = data.title;
-      }
-
+      if (titleEl) titleEl.textContent = data.title || '';
       const copyEl = button.querySelector('.process-step__copy');
-      if (copyEl && data.copy) {
-        copyEl.textContent = data.copy;
-      }
-    };
-
-    const populateDetailContent = (slug) => {
-      const data = stepData.get(slug);
-      const entry = slug ? accordionBySlug.get(slug) : null;
-      if (!data || !entry) return;
-
-      if (entry.trigger) {
-        const numberEl = entry.trigger.querySelector('.process-accordion-number');
-        if (numberEl) {
-          numberEl.textContent = data.number || '';
-        }
-        const titleEl = entry.trigger.querySelector('.process-accordion-title');
-        if (titleEl && data.label) {
-          titleEl.textContent = data.label;
-        }
-      }
-
-      if (entry.panel) {
-        const panelTitle = entry.panel.querySelector('.process-panel__title');
-        if (panelTitle && data.label) {
-          panelTitle.textContent = data.label;
-        }
-        const panelBody = entry.panel.querySelector('.process-panel__body');
-        if (panelBody && data.body) {
-          panelBody.textContent = data.body;
-        }
-        const list = entry.panel.querySelector('.process-panel__list');
-        if (list && Array.isArray(data.bullets)) {
-          list.innerHTML = '';
-          data.bullets.forEach((bullet) => {
-            const item = document.createElement('li');
-            item.textContent = bullet;
-            list.appendChild(item);
-          });
-        }
-      }
-    };
-
-    const applyDetailAccent = (slug) => {
-      if (!detail) return;
-      detailAccentModifiers.forEach((className) => {
-        detail.classList.remove(className);
-      });
-      const data = stepData.get(slug);
-      if (data && data.accent) {
-        detail.classList.add(`is-${data.accent}`);
-      }
-    };
-
-    const toggleAccordionState = (slug) => {
-      accordionEntries.forEach((entry) => {
-        if (!entry || !entry.slug) return;
-        const isActive = entry.slug === slug;
-        if (entry.item) {
-          entry.item.classList.toggle('is-active', isActive);
-        }
-        if (entry.panel) {
-          entry.panel.hidden = !isActive;
-          entry.panel.classList.toggle('is-active', isActive);
-        }
-        if (entry.trigger) {
-          entry.trigger.setAttribute('aria-expanded', isActive ? 'true' : 'false');
-        }
-      });
-    };
-
-    stepSlugs.forEach((slug, index) => {
-      populateStepContent(slug, steps[index]);
-      populateDetailContent(slug);
+      if (copyEl) copyEl.textContent = data.copy || data.body || '';
     });
 
-    section.classList.add('is-enhanced');
+    const card = section.querySelector('[data-process-detail]');
+    const cardElements = card
+      ? {
+          badgeNum: card.querySelector('.process-badge-num'),
+          badgeLabel: card.querySelector('.process-badge-label'),
+          title: card.querySelector('.process-detail-title'),
+          body: card.querySelector('.process-detail-body'),
+          list: card.querySelector('.process-detail-list'),
+        }
+      : null;
 
-    const runner = section.querySelector('[data-process-runner]');
     const baseline = section.querySelector('.process-baseline');
     const baselineFill = section.querySelector('[data-process-baseline-fill], .process-baseline__fill');
-    const baselineTrack = baselineFill ? baselineFill.parentElement : null;
+    const runner = section.querySelector('[data-process-runner]');
+    const stepsHost = section.querySelector('.process-steps');
     let bubble = baseline ? baseline.querySelector('.process-bubble') : null;
     if (baseline && !bubble) {
       bubble = document.createElement('span');
@@ -402,79 +266,128 @@
       bubble.setAttribute('aria-hidden', 'true');
       baseline.appendChild(bubble);
     }
-    const bubbleCooldown = 600;
-    let lastBubbleEmit = 0;
+
     let bubbleRAF = 0;
+    let lastBubbleEmit = 0;
+    const bubbleCooldown = 600;
+
+    const updateDetailCard = (slug) => {
+      if (!cardElements) return;
+      const data = PROCESS_DATA[slug];
+      if (!data) return;
+      if (cardElements.badgeNum) cardElements.badgeNum.textContent = data.num || '';
+      if (cardElements.badgeLabel) cardElements.badgeLabel.textContent = (data.label || '').toString();
+      if (cardElements.title) cardElements.title.textContent = data.title || '';
+      if (cardElements.body) cardElements.body.textContent = data.body || '';
+      if (cardElements.list) {
+        cardElements.list.innerHTML = '';
+        if (Array.isArray(data.bullets)) {
+          data.bullets.forEach((bullet) => {
+            const item = document.createElement('li');
+            item.textContent = bullet;
+            cardElements.list.appendChild(item);
+          });
+        }
+      }
+    };
+
+    const applyCardAccent = (slug) => {
+      if (!card) return;
+      ACCENT_CLASSES.forEach((className) => card.classList.remove(className));
+      const data = PROCESS_DATA[slug];
+      if (data && data.accent) {
+        card.classList.add(`is-${data.accent}`);
+      }
+    };
+
+    const applyAccentVariables = (slug) => {
+      const data = PROCESS_DATA[slug];
+      if (!data) return;
+      const accentRgb = data.accentRgb || '';
+      if (runner) {
+        runner.style.setProperty('--runner-accent-rgb', accentRgb);
+      }
+      if (baselineFill) {
+        baselineFill.style.setProperty('--runner-accent-rgb', accentRgb);
+      }
+      if (bubble) {
+        bubble.style.setProperty('--runner-accent-rgb', accentRgb);
+      }
+    };
+
+    const playCardSwap = (skipAnimation) => {
+      if (!card) return;
+      card.classList.remove('is-swapping');
+      if (skipAnimation) return;
+      void card.offsetWidth;
+      card.classList.add('is-swapping');
+    };
+
     const measureAndEmitBubble = (index, { allowEmit = true } = {}) => {
-      if (!baseline || !bubble || !steps[index] || isCompactViewport()) return;
-
+      if (!baseline || !bubble || !buttons[index] || isCompactViewport()) return;
       const baselineRect = baseline.getBoundingClientRect();
-      const targetRect = steps[index].getBoundingClientRect();
-      const hasBaseline = baselineRect.width || baselineRect.height;
-      if (!hasBaseline) return;
-
-      const isVertical = baselineRect.height > baselineRect.width;
-      if (isVertical) {
-        const centerY = targetRect.top + targetRect.height / 2;
-        const offsetY = clamp(centerY - baselineRect.top, 0, baselineRect.height || 0);
-        bubble.style.setProperty('--bubble-x', `${offsetY.toFixed(2)}px`);
-      } else {
-        const centerX = targetRect.left + targetRect.width / 2;
-        const offsetX = clamp(centerX - baselineRect.left, 0, baselineRect.width || 0);
-        bubble.style.setProperty('--bubble-x', `${offsetX.toFixed(2)}px`);
-      }
-
-      const referenceSize = isVertical ? targetRect.height : targetRect.width;
-      const nextScale = clamp(referenceSize / 28, 7, 9);
-      bubble.style.setProperty('--bubble-scale', nextScale.toFixed(2));
-
+      const targetRect = buttons[index].getBoundingClientRect();
+      if (!baselineRect.width) return;
+      const centerX = targetRect.left + targetRect.width / 2;
+      const offsetX = clamp(centerX - baselineRect.left, 0, baselineRect.width);
+      bubble.style.setProperty('--bubble-x', `${offsetX.toFixed(2)}px`);
+      const scale = clamp(targetRect.width / 28, 7, 9);
+      bubble.style.setProperty('--bubble-scale', scale.toFixed(2));
       if (!allowEmit) return;
-
       const now = typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now();
-      if (now - lastBubbleEmit < bubbleCooldown) {
-        return;
-      }
-
+      if (now - lastBubbleEmit < bubbleCooldown) return;
       lastBubbleEmit = now;
       bubble.classList.remove('process-bubble-emit');
-      // Force reflow so the animation can restart when the class is re-added.
       void bubble.offsetWidth;
       bubble.classList.add('process-bubble-emit');
     };
 
     const scheduleBubbleUpdate = (index, { allowEmit = true } = {}) => {
-      if (!baseline || !bubble || !steps[index] || isCompactViewport()) return;
+      if (!baseline || !bubble || !buttons[index] || isCompactViewport()) return;
       window.cancelAnimationFrame(bubbleRAF);
       bubbleRAF = window.requestAnimationFrame(() => {
         bubbleRAF = 0;
         measureAndEmitBubble(index, { allowEmit });
       });
     };
-    let activeIndex = steps.findIndex((button) => button.getAttribute('aria-current') === 'step' || button.classList.contains('is-active'));
-    if (activeIndex < 0) activeIndex = 0;
 
-    let resizeRAF = 0;
-    let previousCompact = isCompactViewport();
+    const updateBaselineFill = (index) => {
+      if (!baselineFill || !buttons[index]) return;
+      if (isCompactViewport()) {
+        const total = buttons.length;
+        const progress = total > 1 ? index / (total - 1) : 1;
+        baselineFill.style.width = '100%';
+        baselineFill.style.setProperty('--process-baseline-progress', progress.toFixed(4));
+        return;
+      }
+      const trackRect = baselineFill.parentElement ? baselineFill.parentElement.getBoundingClientRect() : baseline.getBoundingClientRect();
+      const targetRect = buttons[index].getBoundingClientRect();
+      if (!trackRect.width) return;
+      const width = clamp(targetRect.left + targetRect.width / 2 - trackRect.left, 0, trackRect.width);
+      baselineFill.style.height = '100%';
+      baselineFill.style.width = `${Math.round(width)}px`;
+      baselineFill.style.setProperty('--process-baseline-progress', '1');
+      baselineFill.style.setProperty('--process-baseline-fill', `${Math.round(width)}px`);
+    };
+
+    const runnerHasTransform = () => runner && runner.style && typeof runner.style.transform === 'string';
 
     const applyRunnerPosition = (index, { immediate = false } = {}) => {
-      if (!runner || !steps[index] || isCompactViewport()) return;
-
+      if (!runner || !buttons[index] || isCompactViewport()) return;
       const parent = runner.parentElement || section;
       const parentRect = parent.getBoundingClientRect();
-      const targetRect = steps[index].getBoundingClientRect();
+      const targetRect = buttons[index].getBoundingClientRect();
       const runnerWidth = runner.offsetWidth || 0;
       const x = targetRect.left + targetRect.width / 2 - parentRect.left - runnerWidth / 2;
-
       const setTransform = () => {
-        runner.style.setProperty('--runner-x', `${Math.round(x)}px`);
-        runner.style.transform = `translate3d(${Math.round(x)}px, 0, 0)`;
+        const rounded = Math.round(x);
+        runner.style.setProperty('--runner-x', `${rounded}px`);
+        runner.style.transform = `translate3d(${rounded}px, 0, 0)`;
       };
-
-      if (prefersReducedMotion() || immediate) {
+      if (prefersReducedMotion() || immediate || !runnerHasTransform()) {
         const previousTransition = runner.style.transition;
         runner.style.transition = 'none';
         setTransform();
-        // Force a reflow so the transition reset takes effect before restoring.
         void runner.offsetWidth;
         runner.style.transition = previousTransition;
       } else {
@@ -482,105 +395,75 @@
       }
     };
 
-    const updateBaselineFill = (index) => {
-      if (!baselineFill || !baselineTrack || !steps[index] || isCompactViewport()) return;
-      const trackRect = baselineTrack.getBoundingClientRect();
-      const targetRect = steps[index].getBoundingClientRect();
-      const isVertical = trackRect.height > trackRect.width;
-      if (isVertical) {
-        const height = clamp(targetRect.top + targetRect.height / 2 - trackRect.top, 0, trackRect.height || 0);
-        baselineFill.style.height = `${Math.round(height)}px`;
-        baselineFill.style.width = '100%';
-        baselineFill.style.setProperty('--process-baseline-fill', `${Math.round(height)}px`);
-        return;
-      }
-
-      const width = clamp(targetRect.left + targetRect.width / 2 - trackRect.left, 0, trackRect.width || 0);
-      baselineFill.style.height = '100%';
-      baselineFill.style.width = `${Math.round(width)}px`;
-      baselineFill.style.setProperty('--process-baseline-fill', `${Math.round(width)}px`);
-    };
-
-    const refreshGeometry = (options = {}) => {
+    let resizeRAF = 0;
+    const refreshGeometry = ({ immediate = false } = {}) => {
       window.cancelAnimationFrame(resizeRAF);
-      if (isCompactViewport()) {
-        resizeRAF = 0;
-        return;
-      }
       resizeRAF = window.requestAnimationFrame(() => {
+        resizeRAF = 0;
         updateBaselineFill(activeIndex);
-        applyRunnerPosition(activeIndex, options);
-        measureAndEmitBubble(activeIndex, { allowEmit: false });
+        if (!isCompactViewport()) {
+          applyRunnerPosition(activeIndex, { immediate });
+          measureAndEmitBubble(activeIndex, { allowEmit: false });
+        }
       });
     };
 
+    const setAriaCurrent = (index) => {
+      buttons.forEach((button, idx) => {
+        if (!button) return;
+        button.setAttribute('aria-current', idx === index ? 'step' : 'false');
+      });
+    };
+
+    const stepsHostScroll = stepsHost;
+    const scrollActiveIntoView = (index) => {
+      if (!stepsHostScroll || !isCompactViewport()) return;
+      const article = stepArticles[index];
+      if (!article) return;
+      const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+      article.scrollIntoView({ block: 'nearest', inline: 'center', behavior });
+    };
+
+    let activeIndex = stepArticles.findIndex((article) => article.classList.contains('is-active'));
+    if (activeIndex < 0) {
+      activeIndex = buttons.findIndex((button) => button.getAttribute('aria-current') === 'step');
+    }
+    if (activeIndex < 0) activeIndex = 0;
+
     const setActiveStep = (index, { focus = false, immediate = false } = {}) => {
-      if (!steps.length) return;
-      const nextIndex = ((index % steps.length) + steps.length) % steps.length;
-      const compact = isCompactViewport();
-      if (activeIndex === nextIndex && !immediate) {
-        if (focus) steps[nextIndex].focus();
-        if (!compact) {
-          scheduleBubbleUpdate(nextIndex, { allowEmit: true });
-        }
-        return;
-      }
-
-      const previousButton = steps[activeIndex];
-      if (previousButton) {
-        previousButton.classList.remove('is-active');
-        previousButton.removeAttribute('aria-current');
-        previousButton.tabIndex = -1;
-        const previousStepItem = previousButton.closest('[data-process-step], .process-step');
-        if (previousStepItem) previousStepItem.classList.remove('is-active');
-      }
-
-      const nextButton = steps[nextIndex];
-      const nextSlug = stepSlugs[nextIndex];
-
-      if (detail) {
-        populateDetailContent(nextSlug);
-        applyDetailAccent(nextSlug);
-      }
-
-      toggleAccordionState(nextSlug);
-
-      nextButton.classList.add('is-active');
-      nextButton.setAttribute('aria-current', 'step');
-      nextButton.tabIndex = 0;
-      const nextStepItem = nextButton.closest('[data-process-step], .process-step');
-      if (nextStepItem) nextStepItem.classList.add('is-active');
-
+      if (!buttons.length) return;
+      const total = buttons.length;
+      const nextIndex = ((index % total) + total) % total;
+      if (activeIndex === nextIndex && !immediate) return;
+      const previousIndex = activeIndex;
       activeIndex = nextIndex;
-      section.setAttribute('data-process-active-index', String(activeIndex));
-
-      if (!compact) {
-        refreshGeometry({ immediate });
+      stepArticles.forEach((article, idx) => {
+        article.classList.toggle('is-active', idx === nextIndex);
+      });
+      setAriaCurrent(nextIndex);
+      const slug = slugForIndex[nextIndex];
+      applyAccentVariables(slug);
+      updateDetailCard(slug);
+      applyCardAccent(slug);
+      playCardSwap(immediate || previousIndex === nextIndex);
+      updateBaselineFill(nextIndex);
+      if (!isCompactViewport()) {
+        applyRunnerPosition(nextIndex, { immediate });
         scheduleBubbleUpdate(nextIndex, { allowEmit: !immediate });
       }
-
+      scrollActiveIntoView(nextIndex);
       if (focus) {
-        nextButton.focus();
+        buttons[nextIndex].focus();
       }
     };
 
-    steps.forEach((button, index) => {
-      if (!button.hasAttribute('type')) {
-        button.type = 'button';
-      }
-      if (index !== activeIndex) {
-        button.tabIndex = -1;
-      } else {
-        button.tabIndex = 0;
-      }
-      const stepItem = button.closest('[data-process-step], .process-step');
-      if (stepItem) {
-        stepItem.dataset.processStepIndex = String(index);
-      }
+    buttons.forEach((button, index) => {
+      if (!button) return;
+      button.setAttribute('type', 'button');
       button.addEventListener(
         'click',
         () => {
-          setActiveStep(index, { focus: true });
+          setActiveStep(index, { focus: false });
         },
         { signal }
       );
@@ -588,15 +471,7 @@
         'keydown',
         (event) => {
           if (event.defaultPrevented) return;
-          if (event.altKey || event.metaKey || event.ctrlKey) return;
-
           switch (event.key) {
-            case 'Enter':
-            case ' ': {
-              event.preventDefault();
-              setActiveStep(index, { focus: true });
-              break;
-            }
             case 'ArrowRight':
             case 'ArrowDown': {
               event.preventDefault();
@@ -616,7 +491,7 @@
             }
             case 'End': {
               event.preventDefault();
-              setActiveStep(steps.length - 1, { focus: true });
+              setActiveStep(buttons.length - 1, { focus: true });
               break;
             }
             default:
@@ -624,44 +499,66 @@
         },
         { signal }
       );
+    });
 
-      const toggleHover = (state) => {
-        const targetStep = button.closest('[data-process-step], .process-step');
-        if (!targetStep) return;
-        if (state) {
-          targetStep.classList.add('is-hover');
-        } else {
-          targetStep.classList.remove('is-hover');
+    if (stepsHostScroll) {
+      let swipeState = null;
+      stepsHostScroll.addEventListener(
+        'pointerdown',
+        (event) => {
+          if (!isCompactViewport()) return;
+          if (event.pointerType && event.pointerType !== 'touch' && event.pointerType !== 'pen') return;
+          swipeState = {
+            id: event.pointerId,
+            startX: event.clientX,
+            startY: event.clientY,
+            startTime: typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now(),
+          };
+          stepsHostScroll.setPointerCapture(event.pointerId);
+        },
+        { signal }
+      );
+
+      stepsHostScroll.addEventListener(
+        'pointermove',
+        (event) => {
+          if (!swipeState || event.pointerId !== swipeState.id) return;
+          swipeState.lastX = event.clientX;
+          swipeState.lastY = event.clientY;
+        },
+        { signal, passive: true }
+      );
+
+      const handleSwipeEnd = (event) => {
+        if (!swipeState || event.pointerId !== swipeState.id) return;
+        stepsHostScroll.releasePointerCapture(event.pointerId);
+        const endX = event.clientX;
+        const endY = event.clientY;
+        const dx = endX - swipeState.startX;
+        const dy = endY - swipeState.startY;
+        const dt =
+          (typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now()) -
+          swipeState.startTime;
+        const absDx = Math.abs(dx);
+        const absDy = Math.abs(dy);
+        const velocity = dt > 0 ? absDx / dt : 0;
+        const distanceThreshold = 40;
+        const velocityThreshold = 0.35;
+        if (absDx > absDy && (absDx > distanceThreshold || velocity > velocityThreshold)) {
+          if (dx < 0) {
+            setActiveStep(activeIndex + 1, { focus: false });
+          } else if (dx > 0) {
+            setActiveStep(activeIndex - 1, { focus: false });
+          }
         }
+        swipeState = null;
       };
 
-      button.addEventListener('mouseenter', () => toggleHover(true), { signal });
-      button.addEventListener('mouseleave', () => toggleHover(false), { signal });
-      button.addEventListener('focus', () => toggleHover(true), { signal });
-      button.addEventListener(
-        'blur',
-        (event) => {
-          if (!button.contains(event.relatedTarget)) {
-            toggleHover(false);
-          }
-        },
-        { signal }
-      );
-    });
+      stepsHostScroll.addEventListener('pointerup', handleSwipeEnd, { signal });
+      stepsHostScroll.addEventListener('pointercancel', handleSwipeEnd, { signal });
+    }
 
-    accordionEntries.forEach((entry) => {
-      if (!entry || !entry.trigger || !entry.slug) return;
-      const targetIndex = slugToIndex.get(entry.slug);
-      if (typeof targetIndex !== 'number') return;
-      entry.trigger.addEventListener(
-        'click',
-        (event) => {
-          if (event.defaultPrevented) return;
-          setActiveStep(targetIndex, { focus: false });
-        },
-        { signal }
-      );
-    });
+    let previousCompact = isCompactViewport();
 
     const handleResize = () => {
       scheduleStarRender();
@@ -669,52 +566,104 @@
       if (compact !== previousCompact) {
         previousCompact = compact;
         setActiveStep(activeIndex, { immediate: true });
+      } else {
+        refreshGeometry({ immediate: true });
       }
-      refreshGeometry({ immediate: true });
-      scheduleBubbleUpdate(activeIndex, { allowEmit: false });
+      if (!compact) {
+        scheduleBubbleUpdate(activeIndex, { allowEmit: false });
+      }
     };
-
-    window.addEventListener('resize', handleResize, { signal });
-    window.addEventListener(
-      'orientationchange',
-      handleResize,
-      { signal }
-    );
 
     const handleReduceMotionChange = () => {
       scheduleStarRender({ force: true });
       refreshGeometry({ immediate: true });
-      scheduleBubbleUpdate(activeIndex, { allowEmit: false });
     };
+
+    window.addEventListener('resize', handleResize, { signal });
+    window.addEventListener('orientationchange', handleResize, { signal });
 
     if (typeof reduceMotionQuery.addEventListener === 'function') {
       reduceMotionQuery.addEventListener('change', handleReduceMotionChange, { signal });
     } else if (typeof reduceMotionQuery.addListener === 'function') {
       reduceMotionQuery.addListener(handleReduceMotionChange);
-      if (controller) {
+      if (controller && signal) {
         signal.addEventListener('abort', () => {
           reduceMotionQuery.removeListener(handleReduceMotionChange);
         });
       }
     }
 
-    const cleanup = () => {
-      if (controller) {
-        controller.abort();
+    let revealObserver;
+    const markRevealTargets = () => {
+      section.classList.add('is-in');
+      revealTargets.forEach((target) => target.classList.add('is-in'));
+    };
+
+    const triggerReveal = () => {
+      if (section.classList.contains('has-seen')) return;
+      section.classList.add('has-seen');
+      markRevealTargets();
+      if (!isCompactViewport()) {
+        window.requestAnimationFrame(() => {
+          refreshGeometry({ immediate: true });
+          applyRunnerPosition(activeIndex, { immediate: true });
+        });
       }
       if (revealObserver) {
         revealObserver.disconnect();
       }
+    };
+
+    if (section.classList.contains('has-seen')) {
+      markRevealTargets();
+    } else if (typeof IntersectionObserver === 'function') {
+      revealObserver = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.target === section && entry.isIntersecting) {
+              triggerReveal();
+            }
+          });
+        },
+        { threshold: 0.2, rootMargin: '0px 0px -12% 0px' }
+      );
+      revealObserver.observe(section);
+      if (computeInitialVisibility()) {
+        triggerReveal();
+      }
+    } else {
+      triggerReveal();
+    }
+
+    const cleanup = () => {
+      if (controller) {
+        controller.abort();
+      }
       if (sectionVisibilityObserver) {
         sectionVisibilityObserver.disconnect();
       }
+      if (revealObserver) {
+        revealObserver.disconnect();
+      }
+      window.cancelAnimationFrame(resizeRAF);
       window.cancelAnimationFrame(bubbleRAF);
     };
 
     window.addEventListener('pagehide', cleanup, { once: true });
     window.addEventListener('beforeunload', cleanup, { once: true });
 
+    section.classList.add('is-enhanced');
+
+    const initialSlug = slugForIndex[activeIndex];
+    applyAccentVariables(initialSlug);
+    updateDetailCard(initialSlug);
+    applyCardAccent(initialSlug);
+    setAriaCurrent(activeIndex);
     setActiveStep(activeIndex, { immediate: true });
+    refreshGeometry({ immediate: true });
+    if (!isCompactViewport()) {
+      scheduleBubbleUpdate(activeIndex, { allowEmit: false });
+    }
   };
 
   if (document.readyState === 'loading') {

--- a/styles/process.css
+++ b/styles/process.css
@@ -6,7 +6,7 @@
 .process {
   position: relative;
   isolation: isolate;
-  padding: clamp(70px, 9vw, 96px) 0 clamp(68px, 10vw, 104px);
+  padding: clamp(56px, 16vw, 78px) 0 clamp(58px, 17vw, 84px);
   color: #f7f3ff;
   background:
     radial-gradient(120% 120% at 18% -20%, rgba(255, 122, 24, 0.26) 0%, rgba(255, 122, 24, 0) 60%),
@@ -36,6 +36,20 @@
   pointer-events: none;
   overflow: hidden;
   z-index: 0;
+}
+
+[data-reveal] {
+  opacity: 0;
+  transform: translate3d(0, 8px, 0);
+  transition:
+    opacity 0.45s cubic-bezier(0.2, 0.8, 0.2, 1) var(--process-reveal-delay, 0s),
+    transform 0.45s cubic-bezier(0.2, 0.8, 0.2, 1) var(--process-reveal-delay, 0s);
+  will-change: opacity, transform;
+}
+
+[data-reveal].is-in {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
 }
 
 .process-star {
@@ -149,55 +163,51 @@
 
 .process__grid {
   display: grid;
-  gap: clamp(26px, 3vw, 32px);
+  gap: clamp(32px, 6vw, 42px);
 }
 
 .process__rail {
   position: relative;
-  display: flex;
-  align-items: stretch;
-  gap: clamp(22px, 2.8vw, 28px);
+  display: block;
+  padding-bottom: clamp(42px, 9vw, 56px);
 }
 
 .process__rail::before {
-  content: "";
-  position: absolute;
-  inset: 42px calc(clamp(22px, 2.4vw, 30px) + 24px);
-  height: 2px;
-  margin-block: auto;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.18), rgba(214, 60, 255, 0.65));
-  pointer-events: none;
-  z-index: 0;
+  content: none;
 }
 
 .process-baseline {
   position: absolute;
-  inset: 42px calc(clamp(22px, 2.4vw, 30px) + 24px);
-  margin-block: auto;
-  height: 2px;
+  left: clamp(6px, 4vw, 16px);
+  right: clamp(6px, 4vw, 16px);
+  bottom: clamp(4px, 2vw, 10px);
+  height: 3px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.1);
   pointer-events: none;
-  overflow: visible;
+  overflow: hidden;
   z-index: 0;
 }
 
 .process-baseline__fill {
+  --runner-accent-rgb: 214, 60, 255;
   position: absolute;
   inset: 0;
-  width: var(--process-baseline-fill, 0px);
+  width: var(--process-baseline-fill, 100%);
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.55), rgba(214, 60, 255, 0.75));
-  transition: width 0.42s var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
-  will-change: width;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.62), rgba(var(--runner-accent-rgb), 0.88));
+  transform-origin: left center;
+  transform: scaleX(var(--process-baseline-progress, 1));
+  transition: width 0.45s cubic-bezier(0.2, 0.8, 0.2, 1), transform 0.45s cubic-bezier(0.2, 0.8, 0.2, 1);
+  will-change: width, transform;
   z-index: 1;
 }
 
 .process-bubble {
   --bubble-duration: 0.36s;
   --bubble-scale: 7.5;
+  --runner-accent-rgb: 214, 60, 255;
   position: absolute;
   top: 50%;
   left: 0;
@@ -206,7 +216,7 @@
   border-radius: 999px;
   pointer-events: none;
   transform: translate3d(var(--bubble-x, 0px), 0, 0) translate(-50%, -50%) scale(1);
-  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.9) 0%, rgba(214, 60, 255, 0.72) 45%, rgba(214, 60, 255, 0) 78%);
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.9) 0%, rgba(var(--runner-accent-rgb), 0.7) 45%, rgba(var(--runner-accent-rgb), 0) 78%);
   opacity: 0;
   mix-blend-mode: screen;
   will-change: transform, opacity;
@@ -231,74 +241,134 @@
   }
 }
 
-.process-step,
-.process-detail {
-  position: relative;
-  border-radius: var(--radius-xl, 22px);
-  background:
-    radial-gradient(140% 180% at 18% 14%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 58%),
-    radial-gradient(160% 200% at 82% 0%, rgba(214, 60, 255, 0.26) 0%, rgba(214, 60, 255, 0) 64%),
-    linear-gradient(160deg, rgba(38, 22, 64, 0.9), rgba(16, 8, 32, 0.92));
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  box-shadow: 0 24px 46px rgba(8, 2, 26, 0.28);
-  color: inherit;
-  overflow: hidden;
+
+.process-steps {
+  display: flex;
+  gap: clamp(18px, 5vw, 24px);
+  overflow-x: auto;
+  padding: clamp(18px, 5vw, 24px) clamp(6px, 4vw, 16px);
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+
+.process-steps::-webkit-scrollbar {
+  height: 4px;
+}
+
+.process-steps::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
 }
 
 .process-step {
-  flex: 1 1 0;
+  --process-accent-1: #6a5dfc;
+  --process-accent-2: #d63cff;
+  --process-accent-ink: #ffffff;
+  --process-accent-rgb: 214, 60, 255;
+  --process-accent-rgb-alt: 132, 80, 255;
+  position: relative;
   display: grid;
-  gap: clamp(16px, 2vw, 20px);
-  padding: clamp(28px, 3vw, 34px);
-  transition: transform var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
-              box-shadow var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
-              border-color var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+  gap: clamp(14px, 3vw, 18px);
+  flex: 0 0 auto;
+  min-width: clamp(220px, 72vw, 280px);
+  padding: clamp(24px, 5vw, 32px);
+  border-radius: var(--radius-xl, 22px);
+  background:
+    radial-gradient(140% 180% at 18% 14%, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0) 60%),
+    radial-gradient(160% 220% at 100% -20%, rgba(var(--process-accent-rgb-alt), 0.24) 0%, rgba(var(--process-accent-rgb-alt), 0) 68%),
+    linear-gradient(165deg, rgba(32, 20, 56, 0.92), rgba(12, 5, 26, 0.96));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 22px 44px rgba(8, 2, 26, 0.32);
+  color: inherit;
+  overflow: hidden;
+  transition: transform 0.32s cubic-bezier(0.2, 0.8, 0.2, 1),
+              box-shadow 0.32s cubic-bezier(0.2, 0.8, 0.2, 1),
+              border-color 0.32s cubic-bezier(0.2, 0.8, 0.2, 1);
+  scroll-snap-align: center;
 }
 
 .process-step::after {
   content: "";
   position: absolute;
   inset: 0;
-  z-index: 0;
-  background: radial-gradient(120% 120% at 20% 20%, rgba(214, 60, 255, 0.42), transparent 65%);
+  border-radius: inherit;
+  background:
+    radial-gradient(120% 120% at 24% 22%, rgba(var(--process-accent-rgb), 0.32), transparent 68%),
+    linear-gradient(150deg, rgba(var(--process-accent-rgb), 0.18), rgba(var(--process-accent-rgb-alt), 0.08));
   opacity: 0;
-  transition: opacity var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+  transition: opacity 0.32s cubic-bezier(0.2, 0.8, 0.2, 1);
+  pointer-events: none;
 }
 
-.process-step > * { position: relative; z-index: 1; }
+.process-step > * {
+  position: relative;
+  z-index: 1;
+}
+
+.process-step-button {
+  display: grid;
+  gap: clamp(12px, 3vw, 16px);
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
 
 .process-step__badge {
+  --badge-border: rgba(255, 255, 255, 0.14);
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.55rem;
+  gap: 0.5rem;
   align-self: flex-start;
-  padding: 0.55rem 0.9rem;
+  padding: 0.38rem 0.55rem 0.38rem 0.38rem;
   border-radius: 999px;
-  background: rgba(17, 8, 34, 0.62);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  color: rgba(249, 243, 255, 0.84);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 13px;
+  background: rgba(12, 5, 26, 0.62);
+  border: 1px solid var(--badge-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(4px);
 }
 
-.process-step__icon {
+.process-step__badge-num {
+  --accent-1: var(--process-accent-1, #6a5dfc);
+  --accent-2: var(--process-accent-2, #d63cff);
+  --accent-ink: var(--process-accent-ink, #ffffff);
+  display: inline-grid;
+  place-items: center;
   width: 38px;
   height: 38px;
   border-radius: 12px;
-  background: var(--grad);
-  display: inline-grid;
-  place-items: center;
-  color: #180b2e;
+  background: linear-gradient(140deg, var(--accent-1), var(--accent-2));
+  color: var(--accent-ink);
   font-size: 18px;
-  box-shadow: 0 10px 24px rgba(214, 60, 255, 0.4);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  box-shadow:
+    0 12px 24px rgba(0, 0, 0, 0.22),
+    0 0 22px rgba(var(--process-accent-rgb), 0.32);
+}
+
+.process-step__badge-label {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.28rem 0.72rem;
+  border-radius: 999px;
+  background: rgba(6, 2, 18, 0.74);
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .process-step__title {
   margin: 0;
-  font-size: clamp(20px, 2.8vw, 24px);
+  font-size: clamp(20px, 3.4vw, 24px);
   font-weight: 600;
   letter-spacing: -0.01em;
   color: #fefbff;
@@ -308,90 +378,295 @@
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: rgba(244, 236, 255, 0.68);
+  color: rgba(244, 236, 255, 0.7);
 }
 
-.process-step__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 16px;
-  margin-top: auto;
+.process-step.is-active {
+  border-color: rgba(var(--process-accent-rgb), 0.45);
+  box-shadow:
+    0 26px 52px rgba(8, 2, 26, 0.36),
+    0 0 36px rgba(var(--process-accent-rgb), 0.32);
+  transform: translateY(-4px);
 }
 
-.process-step__actions .process-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.1rem;
-  border-radius: 999px;
-  font-weight: 600;
-  font-size: 15px;
-  letter-spacing: 0.01em;
-  background: rgba(17, 10, 30, 0.64);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  color: #f8f4ff;
-  box-shadow: 0 10px 26px rgba(8, 2, 26, 0.24);
-  transition: transform var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
-              box-shadow var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1)),
-              border-color var(--dur, 0.35s) var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
+.process-step.is-active::after {
+  opacity: 1;
 }
 
-.process-btn--primary {
-  background: var(--grad);
-  border-color: transparent;
-  color: #140824;
-  box-shadow: 0 12px 34px rgba(214, 60, 255, 0.44);
-}
-
-.process-btn--ghost {
-  background: rgba(255, 255, 255, 0.08);
+.process-step.is-active .process-step__badge-num {
+  box-shadow:
+    0 16px 30px rgba(0, 0, 0, 0.24),
+    0 0 26px rgba(var(--process-accent-rgb), 0.42);
 }
 
 .process-step:where(:hover, :focus-within) {
   transform: translateY(-6px);
-  box-shadow:
-    0 24px 46px rgba(8, 2, 26, 0.28),
-    0 0 30px rgba(214, 60, 255, 0.35);
   border-color: rgba(255, 255, 255, 0.26);
+  box-shadow:
+    0 26px 52px rgba(8, 2, 26, 0.34),
+    0 0 32px rgba(var(--process-accent-rgb), 0.24);
 }
 
-.process-step:where(:hover, :focus-within)::after { opacity: 1; }
+.process-step:where(:hover, :focus-within)::after {
+  opacity: 1;
+}
 
 .process-step:active {
   transform: translateY(-2px);
 }
 
 .process-step a,
-.process-step button,
-.process-step .process-btn {
+.process-step button {
   position: relative;
   z-index: 1;
 }
 
 .process-step a:focus-visible,
-.process-step button:focus-visible,
-.process-step .process-btn:focus-visible {
+.process-step button:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.9);
   outline-offset: 3px;
   box-shadow: 0 0 0 4px rgba(20, 8, 36, 0.5);
 }
 
-.process-step__actions .process-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 36px rgba(8, 2, 26, 0.3);
+.process-step--discover {
+  --process-accent-1: #2d8bff;
+  --process-accent-2: #1de5ff;
+  --process-accent-ink: #ffffff;
+  --process-accent-rgb: 45, 139, 255;
+  --process-accent-rgb-alt: 29, 229, 255;
 }
 
-.process-step__actions .process-btn:active {
-  transform: translateY(0);
+.process-step--design {
+  --process-accent-1: #a248ff;
+  --process-accent-2: #ff64f2;
+  --process-accent-ink: #ffffff;
+  --process-accent-rgb: 162, 72, 255;
+  --process-accent-rgb-alt: 255, 100, 242;
+}
+
+.process-step--build {
+  --process-accent-1: #ff8a3c;
+  --process-accent-2: #ff4554;
+  --process-accent-ink: #ffffff;
+  --process-accent-rgb: 255, 138, 60;
+  --process-accent-rgb-alt: 255, 69, 84;
+}
+
+.process-step--launch {
+  --process-accent-1: #44f28d;
+  --process-accent-2: #1ecb79;
+  --process-accent-ink: #082819;
+  --process-accent-rgb: 68, 242, 141;
+  --process-accent-rgb-alt: 30, 203, 121;
+}
+
+.process-detail {
+  position: relative;
+}
+
+.process-detail-card {
+  --accent-1: #2d8bff;
+  --accent-2: #1de5ff;
+  --accent-ink: #ffffff;
+  --accent-rgb: 45, 139, 255;
+  --accent-rgb-alt: 29, 229, 255;
+  position: relative;
+  display: grid;
+  gap: clamp(18px, 3.2vw, 24px);
+  padding: clamp(28px, 6vw, 36px);
+  border-radius: 26px;
+  background:
+    linear-gradient(175deg, rgba(22, 12, 36, 0.92), rgba(10, 4, 24, 0.96)),
+    radial-gradient(160% 220% at 100% -38%, rgba(var(--accent-rgb-alt), 0.2), rgba(var(--accent-rgb-alt), 0) 64%);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow:
+    0 28px 54px rgba(6, 1, 20, 0.48),
+    0 0 36px rgba(var(--accent-rgb), 0.2);
+  color: #ffffff;
+  isolation: isolate;
+  overflow: hidden;
+  transition: border-color 0.4s cubic-bezier(0.22, 0.84, 0.3, 1),
+              box-shadow 0.4s cubic-bezier(0.22, 0.84, 0.3, 1),
+              background 0.4s cubic-bezier(0.22, 0.84, 0.3, 1);
+}
+
+.process-detail-card::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(var(--accent-rgb), 0.26), rgba(var(--accent-rgb-alt), 0.14));
+  opacity: 0.6;
+  z-index: -1;
+}
+
+.process-detail-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(120% 160% at 12% 12%, rgba(255, 255, 255, 0.12), transparent 62%),
+    radial-gradient(160% 200% at 80% 0%, rgba(var(--accent-rgb), 0.16), transparent 68%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.process-detail-header {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.process-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.36rem 0.55rem 0.36rem 0.36rem;
+  border-radius: 999px;
+  background: rgba(12, 5, 26, 0.64);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(4px);
+}
+
+.process-badge-num {
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: linear-gradient(150deg, var(--accent-1), var(--accent-2));
+  color: var(--accent-ink);
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  box-shadow:
+    0 14px 24px rgba(0, 0, 0, 0.24),
+    0 0 26px rgba(var(--accent-rgb), 0.38);
+}
+
+.process-badge-label {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.26rem 0.76rem;
+  border-radius: 999px;
+  background: rgba(6, 2, 18, 0.78);
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.process-detail-title {
+  margin: 0;
+  font-size: clamp(22px, 3.6vw, 28px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: #ffffff;
+}
+
+.process-detail-body {
+  margin: 0;
+  color: rgba(244, 236, 255, 0.82);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.process-detail-list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+  list-style: none;
+}
+
+.process-detail-list li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 15px;
+  line-height: 1.6;
+  color: rgba(244, 236, 255, 0.78);
+}
+
+.process-detail-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55em;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent-1) 0%, rgba(var(--accent-rgb), 0.18) 72%, transparent 100%);
+  box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.14);
+}
+
+.process-detail-card.is-swapping {
+  animation: processDetailSwap 0.24s cubic-bezier(0.22, 0.84, 0.3, 1);
+}
+
+@keyframes processDetailSwap {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 6px, 0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.process-detail-card.is-design {
+  --accent-1: #a248ff;
+  --accent-2: #ff64f2;
+  --accent-ink: #ffffff;
+  --accent-rgb: 162, 72, 255;
+  --accent-rgb-alt: 255, 100, 242;
+}
+
+.process-detail-card.is-build {
+  --accent-1: #ff8a3c;
+  --accent-2: #ff4554;
+  --accent-ink: #ffffff;
+  --accent-rgb: 255, 138, 60;
+  --accent-rgb-alt: 255, 69, 84;
+}
+
+.process-detail-card.is-launch {
+  --accent-1: #44f28d;
+  --accent-2: #1ecb79;
+  --accent-ink: #082819;
+  --accent-rgb: 68, 242, 141;
+  --accent-rgb-alt: 30, 203, 121;
+}
+
+.process-runner {
+  --runner-accent-rgb: 214, 60, 255;
+  position: absolute;
+  bottom: clamp(6px, 2vw, 12px);
+  left: clamp(12px, 4vw, 16px);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, rgba(var(--runner-accent-rgb), 0.65) 65%, rgba(var(--runner-accent-rgb), 0) 100%);
+  box-shadow: 0 0 22px rgba(var(--runner-accent-rgb), 0.55);
+  transform: translate3d(0, 0, 0);
+  opacity: 0;
+  display: none;
+  transition: opacity 0.32s ease, transform 0.45s cubic-bezier(0.2, 0.8, 0.2, 1);
+  pointer-events: none;
+}
+
+.process.is-in .process-runner {
+  opacity: 1;
 }
 
 .process__cta {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 18px;
-  padding: clamp(26px, 3vw, 32px);
+  padding: clamp(24px, 6vw, 32px);
   border-radius: var(--radius-lg, 16px);
   background: rgba(20, 11, 38, 0.65);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -473,120 +748,107 @@
   opacity: 1;
 }
 
-@media (max-width: 1023px) {
-  .process__rail { align-items: stretch; }
-}
-
-@media (max-width: 767px) {
+@media (min-width: 768px) {
   .process {
-    padding: clamp(52px, 16vw, 78px) 0 clamp(58px, 15vw, 84px);
+    padding: clamp(70px, 9vw, 96px) 0 clamp(68px, 10vw, 104px);
+  }
+
+  .process__grid {
+    grid-template-columns: minmax(0, 1.12fr) minmax(0, 0.95fr);
+    align-items: start;
+    gap: clamp(36px, 4vw, 44px);
   }
 
   .process__rail {
-    flex-direction: column;
+    padding-bottom: clamp(40px, 5vw, 54px);
   }
 
-  .process__rail::before {
-    top: calc(clamp(28px, 5vw, 34px) + 46px);
-    bottom: calc(clamp(28px, 5vw, 34px) + 46px);
-    left: calc(clamp(28px, 5vw, 34px) + 19px);
-    right: auto;
-    width: 2px;
-    height: auto;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(214, 60, 255, 0.65));
+  .process__cta {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
   }
 
-  .process-baseline {
-    top: calc(clamp(28px, 5vw, 34px) + 46px);
-    bottom: calc(clamp(28px, 5vw, 34px) + 46px);
-    left: calc(clamp(28px, 5vw, 34px) + 19px);
-    right: auto;
-    width: 2px;
-    height: auto;
-    background: rgba(255, 255, 255, 0.1);
-  }
-
-  .process-baseline__fill {
-    width: 100%;
-    height: var(--process-baseline-fill, 0px);
-    transition: height 0.42s var(--ease, cubic-bezier(0.2, 0.8, 0.2, 1));
-  }
-
-  .process-bubble {
-    top: 0;
-    left: 50%;
-    transform: translate3d(0, var(--bubble-x, 0px), 0) translate(-50%, -50%) scale(1);
+  .process-steps {
+    overflow: visible;
+    padding: clamp(26px, 3vw, 32px);
+    gap: clamp(22px, 2.6vw, 28px);
   }
 
   .process-step {
-    padding: clamp(24px, 6vw, 32px);
+    flex: 1 1 0;
+    min-width: 0;
+    scroll-snap-align: unset;
   }
 
-  .process-step__actions { justify-content: flex-start; }
-
-  .process__cta {
-    flex-direction: column;
-    align-items: flex-start;
+  .process-baseline {
+    left: clamp(26px, 3vw, 32px);
+    right: clamp(26px, 3vw, 32px);
+    bottom: clamp(12px, 2vw, 20px);
+    height: 2px;
   }
 
-  @keyframes processBubbleExpand {
-    0% {
-      transform: translate3d(0, var(--bubble-x, 0px), 0) translate(-50%, -50%) scale(1);
-      opacity: 0.55;
-    }
-    60% {
-      opacity: 0.75;
-    }
-    100% {
-      transform: translate3d(0, var(--bubble-x, 0px), 0) translate(-50%, -50%) scale(var(--bubble-scale, 8));
-      opacity: 0;
-    }
+  .process-runner {
+    display: block;
+    bottom: clamp(12px, 2vw, 18px);
+  }
+}
+
+@media (min-width: 1024px) {
+  .process-step {
+    gap: clamp(16px, 2.2vw, 20px);
+    padding: clamp(28px, 3vw, 34px);
+  }
+
+  .process-detail-card {
+    padding: clamp(32px, 3.6vw, 40px);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .process,
-  .process * {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
+  .process {
+    scroll-behavior: auto;
   }
 
-  .process::before,
-  .process::after {
-    animation: none;
+  [data-reveal] {
+    transform: none;
+    transition:
+      opacity 0.25s ease var(--process-reveal-delay, 0s);
   }
 
-  .process-step:where(:hover, :focus-within) {
+  .process-detail-card.is-swapping {
+    animation: processDetailFade 0.2s ease;
+  }
+
+  .process-step,
+  .process-step:where(:hover, :focus-within),
+  .process-step.is-active {
     transform: translateY(0);
   }
 
-  .process-step__actions .process-btn:hover,
-  .process-step__actions .process-btn:active {
-    transform: none;
-  }
-
-  .process__cta-actions .btn-ghost::after {
-    animation: none !important;
-    transform: scaleX(1);
-    opacity: 0;
-    transition: opacity 0.25s ease !important;
-  }
-
-  .process__cta-actions .btn-ghost:is(:hover, :focus-visible)::after {
-    opacity: 1;
+  .process-runner {
+    transition-duration: 0.01ms;
   }
 
   .process-bubble {
     animation: none;
-    transition: opacity 0.28s ease;
+    transition: opacity 0.24s ease;
     transform: translate3d(var(--bubble-x, 0px), 0, 0) translate(-50%, -50%) scale(1) !important;
   }
 
   .process-bubble.process-bubble-emit {
     opacity: 0.55;
     animation: processBubbleFade 0.28s ease-out;
+  }
+}
+
+@keyframes processDetailFade {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the Process accordion with a single detail card and refreshed step markup
- restyle the section to use glass cards, per-step accents, responsive snap scrolling, and reveal animations
- rebuild the process logic to drive card swaps, reveal-once behavior, and mobile swipe interactions from a static data map

## Testing
- node --check scripts/process.js

------
https://chatgpt.com/codex/tasks/task_e_68d5cc5b4f2c832f851161d8747ac3e5