### PR TITLE
Add packs pricing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="./styles/labs.css" />
   <link rel="stylesheet" href="./styles/process.css" />
   <link rel="stylesheet" href="./styles/about.css" />
+  <link rel="stylesheet" href="./styles/packs.css" />
 </head>
 <body>
   <!-- // FIX: Added visible fallback notice for no-JS scenarios -->
@@ -332,6 +333,145 @@
     </div>
   </section>
 
+  <section id="packs" class="packs" aria-labelledby="packs-title" data-packs-section>
+    <div class="packs__inner">
+      <header class="packs__head" data-reveal data-reveal-index="0">
+        <h2 id="packs-title" class="packs__title">Choose Your <span class="grad-word">Pack</span></h2>
+        <p class="packs__lede">Transparent pricing for every stage of your digital journey</p>
+      </header>
+
+      <ul class="packs__grid" role="list" data-packs-grid data-reveal data-reveal-index="1">
+        <li>
+          <article class="pack" data-accent="starter" aria-labelledby="pack-starter-title" aria-describedby="pack-starter-price pack-starter-desc">
+            <div class="pack__icon" aria-hidden="true">
+              <svg viewBox="0 0 28 28" width="28" height="28" role="img" aria-hidden="true">
+                <path d="M14 2.5 17 10h7l-5.8 4.2 2.2 7-6.4-4.5-6.4 4.5 2.2-7L4 10h7z" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"></path>
+              </svg>
+            </div>
+            <h3 id="pack-starter-title" class="pack__title">Starter</h3>
+            <p id="pack-starter-desc" class="pack__desc">Perfect for businesses getting online</p>
+            <p id="pack-starter-price" class="pack__price"><span class="val">$2,999</span> <span class="unit">/one-time</span></p>
+            <ul class="pack__list" role="list">
+              <li>Industry-specific website</li>
+              <li>CMS basics</li>
+              <li>Contact forms</li>
+              <li>Mobile responsive</li>
+              <li>3 months support</li>
+            </ul>
+            <a class="pack__cta" href="#contact" aria-label="Get started: Starter, $2,999 one-time">Get Started</a>
+          </article>
+        </li>
+
+        <li>
+          <article class="pack is-featured" data-accent="builder" aria-labelledby="pack-builder-title" aria-describedby="pack-builder-price pack-builder-desc" aria-label="Most Popular plan">
+            <div class="pack__badge" aria-hidden="true">Most Popular</div>
+            <div class="pack__icon" aria-hidden="true">
+              <svg viewBox="0 0 28 28" width="28" height="28" role="img" aria-hidden="true">
+                <path d="M13.5 2v9.5H8L14.5 26V16.5H20L13.5 2Z" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"></path>
+              </svg>
+            </div>
+            <h3 id="pack-builder-title" class="pack__title">Builder</h3>
+            <p id="pack-builder-desc" class="pack__desc">Advanced functionality and integrations</p>
+            <p id="pack-builder-price" class="pack__price"><span class="val">$7,999</span> <span class="unit">/project</span></p>
+            <ul class="pack__list" role="list">
+              <li>Custom APIs</li>
+              <li>Admin dashboards</li>
+              <li>CRM integration</li>
+              <li>Payment processing</li>
+              <li>Advanced analytics</li>
+              <li>6 months support</li>
+            </ul>
+            <a class="pack__cta pack__cta--primary" href="#contact" aria-label="Get started: Builder, $7,999 per project">Get Started</a>
+          </article>
+        </li>
+
+        <li>
+          <article class="pack" data-accent="engine" aria-labelledby="pack-engine-title" aria-describedby="pack-engine-price pack-engine-desc">
+            <div class="pack__icon" aria-hidden="true">
+              <svg viewBox="0 0 28 28" width="28" height="28" role="img" aria-hidden="true">
+                <path d="M6 8.5c0-3.3 3.6-5.5 8-5.5s8 2.2 8 5.5-3.6 5.5-8 5.5-8-2.2-8-5.5Zm0 5c0 3.3 3.6 5.5 8 5.5s8-2.2 8-5.5M6 18.5c0 3.3 3.6 5.5 8 5.5s8-2.2 8-5.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+              </svg>
+            </div>
+            <h3 id="pack-engine-title" class="pack__title">Engine</h3>
+            <p id="pack-engine-desc" class="pack__desc">Data-driven enterprise solutions</p>
+            <p id="pack-engine-price" class="pack__price"><span class="val">$15,999</span> <span class="unit">/project</span></p>
+            <ul class="pack__list" role="list">
+              <li>Data pipelines</li>
+              <li>Data warehouses</li>
+              <li>BI dashboards</li>
+              <li>Real-time analytics</li>
+              <li>Machine learning</li>
+              <li>12 months support</li>
+            </ul>
+            <a class="pack__cta" href="#contact" aria-label="Get started: Engine, $15,999 per project">Get Started</a>
+          </article>
+        </li>
+
+        <li>
+          <article class="pack" data-accent="growth" aria-labelledby="pack-growth-title" aria-describedby="pack-growth-price pack-growth-desc">
+            <div class="pack__icon" aria-hidden="true">
+              <svg viewBox="0 0 28 28" width="28" height="28" role="img" aria-hidden="true">
+                <path d="M4 18.5 11.5 11l4 4L24 6.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+                <path d="M18 6h6v6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </div>
+            <h3 id="pack-growth-title" class="pack__title">Growth</h3>
+            <p id="pack-growth-desc" class="pack__desc">Complete digital marketing solution</p>
+            <p id="pack-growth-price" class="pack__price"><span class="val">$12,999</span> <span class="unit">/campaign</span></p>
+            <ul class="pack__list" role="list">
+              <li>SEO optimization</li>
+              <li>Lead generation flows</li>
+              <li>Fee-smart checkout</li>
+              <li>Marketing automation</li>
+              <li>Analytics &amp; reporting</li>
+              <li>Ongoing optimization</li>
+            </ul>
+            <a class="pack__cta" href="#contact" aria-label="Get started: Growth, $12,999 per campaign">Get Started</a>
+          </article>
+        </li>
+      </ul>
+
+      <section class="addons" aria-labelledby="addons-title" data-reveal data-reveal-index="2">
+        <header class="addons__head">
+          <h3 id="addons-title" class="addons__title">Add-ons</h3>
+          <p class="addons__lede">Enhance your pack with additional features</p>
+        </header>
+
+        <ul class="addons__grid" role="list">
+          <li>
+            <article class="addon" data-accent="ai">
+              <h4 class="addon__title">AI Bot</h4>
+              <p class="addon__price">$1,999</p>
+            </article>
+          </li>
+          <li>
+            <article class="addon" data-accent="swiftpay">
+              <h4 class="addon__title">SwiftPay Mini</h4>
+              <p class="addon__price">$999</p>
+            </article>
+          </li>
+          <li>
+            <article class="addon" data-accent="app">
+              <h4 class="addon__title">App Shell</h4>
+              <p class="addon__price">$3,999</p>
+            </article>
+          </li>
+          <li>
+            <article class="addon" data-accent="devops">
+              <h4 class="addon__title">DevOps Setup</h4>
+              <p class="addon__price">$2,499</p>
+            </article>
+          </li>
+        </ul>
+
+        <div class="addons__ctaRow">
+          <p class="addons__prompt">Need a custom solution? Let’s talk about your specific requirements.</p>
+          <a class="addons__cta" href="#contact" aria-label="Request a custom quote">Get Custom Quote</a>
+        </div>
+      </section>
+    </div>
+  </section>
+
   <section id="process" class="process" aria-labelledby="process-title" data-process-section>
     <div class="process-stars" aria-hidden="true"></div>
     <div class="process__inner">
@@ -589,6 +729,7 @@
   <script src="./scripts/services.js" type="module"></script>
   <script src="./scripts/portfolio.js" type="module"></script>
   <script src="./scripts/labs.js" type="module"></script>
+  <script src="./scripts/packs.js" type="module"></script>
   <!-- // FIX: Load guarded process script safely after styles -->
   <script src="./scripts/process.js" defer></script>
 </body>

--- a/scripts/packs.js
+++ b/scripts/packs.js
@@ -1,0 +1,98 @@
+const packsSection = document.querySelector('[data-packs-section]');
+
+if (!packsSection) {
+  // No packs section present; abort.
+} else {
+  document.body.classList.add('is-packs-js');
+
+  const revealTargets = Array.from(packsSection.querySelectorAll('[data-reveal]'));
+  const isReducedMotionQuery = typeof window.matchMedia === 'function' ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+
+  const setReducedMotionState = (event) => {
+    if (event.matches) {
+      document.body.classList.add('is-packs-reduced');
+    } else {
+      document.body.classList.remove('is-packs-reduced');
+    }
+  };
+
+  if (isReducedMotionQuery) {
+    setReducedMotionState(isReducedMotionQuery);
+
+    if (typeof isReducedMotionQuery.addEventListener === 'function') {
+      isReducedMotionQuery.addEventListener('change', setReducedMotionState);
+    } else if (typeof isReducedMotionQuery.addListener === 'function') {
+      isReducedMotionQuery.addListener(setReducedMotionState);
+    }
+  }
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-in');
+            obs.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        threshold: 0.18,
+      },
+    );
+
+    revealTargets.forEach((target) => observer.observe(target));
+  } else {
+    revealTargets.forEach((target) => target.classList.add('is-in'));
+  }
+
+  const setHoverState = (root, itemSelector) => {
+    if (!root) return;
+
+    const toggleHover = (target, shouldAdd) => {
+      if (!target) return;
+      target.classList[shouldAdd ? 'add' : 'remove']('is-hover');
+    };
+
+    root.addEventListener('mouseover', (event) => {
+      const card = event.target.closest(itemSelector);
+      if (!card || !root.contains(card)) return;
+      toggleHover(card, true);
+    });
+
+    root.addEventListener('mouseout', (event) => {
+      const card = event.target.closest(itemSelector);
+      if (!card || !root.contains(card)) return;
+      const related = event.relatedTarget;
+      if (related && card.contains(related)) {
+        return;
+      }
+      toggleHover(card, false);
+    });
+
+    root.addEventListener('focusin', (event) => {
+      const card = event.target.closest(itemSelector);
+      toggleHover(card, true);
+    });
+
+    root.addEventListener('focusout', (event) => {
+      const card = event.target.closest(itemSelector);
+      if (!card) return;
+      const nextFocus = event.relatedTarget;
+      if (nextFocus && card.contains(nextFocus)) {
+        return;
+      }
+      toggleHover(card, false);
+    });
+  };
+
+  setHoverState(packsSection.querySelector('[data-packs-grid]'), '.pack');
+  setHoverState(packsSection.querySelector('.addons__grid'), '.addon');
+
+  const ctas = packsSection.querySelectorAll('.pack__cta, .addons__cta');
+  ctas.forEach((cta) => {
+    if (cta.getAttribute('href') !== '#contact') {
+      cta.setAttribute('href', '#contact');
+    }
+  });
+}

--- a/styles/packs.css
+++ b/styles/packs.css
@@ -3,9 +3,9 @@
   padding: clamp(72px, 12vw, 120px) 0 clamp(88px, 14vw, 140px);
   color: #f7f3ff;
   background:
-    radial-gradient(120% 140% at 12% 18%, rgba(123, 76, 255, 0.22), transparent 65%),
-    radial-gradient(80% 110% at 85% 20%, rgba(255, 150, 43, 0.2), transparent 70%),
-    linear-gradient(180deg, #1a0f2f 0%, #120820 54%, #0d051a 100%);
+    radial-gradient(95% 120% at 16% 18%, rgba(255, 150, 43, 0.22), rgba(255, 150, 43, 0) 68%),
+    radial-gradient(85% 115% at 82% 82%, rgba(214, 60, 255, 0.25), rgba(214, 60, 255, 0) 72%),
+    linear-gradient(180deg, #0d0718 0%, #170b2d 52%, #110622 100%);
   overflow: hidden;
   isolation: isolate;
 }
@@ -14,42 +14,38 @@
 .packs::after {
   content: "";
   position: absolute;
-  inset: 0;
+  width: 2px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
   pointer-events: none;
+  z-index: 0;
+  opacity: 0.75;
+  animation: labs-star-twinkle 6.8s ease-in-out infinite alternate;
 }
 
 .packs::before {
-  background: radial-gradient(260px 260px at 18% 28%, rgba(255, 255, 255, 0.18), transparent 72%),
-    radial-gradient(320px 320px at 82% 12%, rgba(214, 60, 255, 0.18), transparent 74%),
-    radial-gradient(360px 360px at 88% 80%, rgba(35, 211, 116, 0.16), transparent 78%);
-  opacity: 0.65;
-  mix-blend-mode: screen;
-  z-index: 0;
+  top: clamp(40px, 9vw, 110px);
+  left: clamp(60px, 12vw, 180px);
+  box-shadow:
+    140px -30px 0 0 rgba(255, 255, 255, 0.7),
+    320px 20px 0 0 rgba(214, 60, 255, 0.55),
+    520px -60px 0 0 rgba(123, 206, 255, 0.5),
+    680px 40px 0 0 rgba(255, 150, 43, 0.45),
+    -120px 60px 0 0 rgba(214, 60, 255, 0.45),
+    60px 160px 0 0 rgba(255, 255, 255, 0.65);
 }
 
 .packs::after {
-  width: 2px;
-  height: 2px;
-  top: 18%;
-  left: 24%;
-  right: auto;
-  bottom: auto;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.85);
+  bottom: clamp(40px, 10vw, 120px);
+  right: clamp(48px, 11vw, 180px);
   box-shadow:
-    120px -30px 0 0 rgba(255, 255, 255, 0.7),
-    260px 80px 0 0 rgba(214, 60, 255, 0.55),
-    420px -20px 0 0 rgba(123, 206, 255, 0.5),
-    560px 120px 0 0 rgba(255, 150, 43, 0.55),
-    720px 40px 0 0 rgba(255, 255, 255, 0.6),
-    -140px 60px 0 0 rgba(214, 60, 255, 0.5),
-    -260px 180px 0 0 rgba(83, 235, 165, 0.45),
-    80px 220px 0 0 rgba(255, 255, 255, 0.55),
-    360px 260px 0 0 rgba(255, 150, 43, 0.4),
-    540px 200px 0 0 rgba(214, 60, 255, 0.5);
-  opacity: 0.65;
-  animation: labs-star-twinkle 6s ease-in-out infinite alternate;
-  z-index: 0;
+    -120px -30px 0 0 rgba(255, 255, 255, 0.72),
+    -280px -80px 0 0 rgba(214, 60, 255, 0.52),
+    -420px 10px 0 0 rgba(83, 235, 165, 0.4),
+    -560px -60px 0 0 rgba(255, 150, 43, 0.4),
+    100px -120px 0 0 rgba(255, 255, 255, 0.58),
+    -40px 80px 0 0 rgba(214, 60, 255, 0.48);
 }
 
 .packs__inner {
@@ -71,7 +67,7 @@
 .packs__title {
   font-size: clamp(38px, 5.6vw, 60px);
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
   color: #f7f3ff;
 }
 
@@ -82,15 +78,16 @@
 }
 
 .packs__lede {
-  font-size: clamp(16px, 2.6vw, 18px);
+  font-size: clamp(16px, 2.4vw, 18px);
   max-width: 540px;
   color: rgba(244, 236, 255, 0.78);
+  text-align: center;
 }
 
 .packs__grid {
   list-style: none;
   display: grid;
-  grid-template-columns: repeat(4, minmax(280px, 1fr));
+  grid-template-columns: repeat(4, minmax(300px, 1fr));
   gap: clamp(16px, 3vw, 24px);
   padding: 0;
   margin: 0;
@@ -98,7 +95,7 @@
 
 @media (max-width: 1024px) {
   .packs__grid {
-    grid-template-columns: repeat(2, minmax(280px, 1fr));
+    grid-template-columns: repeat(2, minmax(300px, 1fr));
   }
 }
 
@@ -139,11 +136,6 @@
   mix-blend-mode: screen;
 }
 
-.pack::before {
-  padding: 0;
-  border-radius: inherit;
-}
-
 .pack[data-accent="starter"] {
   --accent-start: #2aa9ff;
   --accent-end: #7bd6ff;
@@ -166,18 +158,18 @@
 
 .pack[data-accent]::after {
   background-image:
-    radial-gradient(220px 160px at 78% 48%, rgba(255, 255, 255, 0.18), transparent 74%),
-    radial-gradient(280px 200px at 82% 52%, color-mix(in srgb, var(--accent-end) 62%, transparent), transparent 72%),
-    linear-gradient(180deg, color-mix(in srgb, var(--accent-start) 54%, transparent) 0%, transparent 72%);
+    radial-gradient(320px 320px at 78% 50%, color-mix(in srgb, var(--accent-end) 64%, transparent) 0%, transparent 70%),
+    radial-gradient(240px 220px at 76% 48%, rgba(255, 255, 255, 0.22), transparent 74%),
+    linear-gradient(180deg, transparent 0%, transparent 35%, color-mix(in srgb, var(--accent-start) 55%, transparent) 50%, transparent 82%);
   background-repeat: no-repeat;
   background-position:
-    74% 52%,
     78% 52%,
-    calc(100% - clamp(10px, 2.4vw, 16px)) 50%;
+    74% 48%,
+    calc(100% - clamp(8px, 2vw, 12px)) center;
   background-size:
-    340px 220px,
-    420px 260px,
-    clamp(8px, 2vw, 12px) 72%;
+    360px 360px,
+    280px 260px,
+    clamp(10px, 2.2vw, 12px) 82%;
 }
 
 .pack:hover,
@@ -189,11 +181,8 @@
 }
 
 .pack:hover::after,
-.pack:hover::before,
 .pack:focus-within::after,
-.pack:focus-within::before,
-.pack.is-hover::after,
-.pack.is-hover::before {
+.pack.is-hover::after {
   opacity: 1;
 }
 
@@ -206,7 +195,7 @@
   border-radius: 999px;
   font-size: 13px;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   color: #f7f3ff;
   background: linear-gradient(145deg, rgba(32, 18, 60, 0.86) 0%, rgba(14, 6, 26, 0.86) 100%);
   border: 1px solid rgba(255, 255, 255, 0.18);
@@ -249,13 +238,13 @@
   align-items: center;
   justify-content: center;
   background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-  color: #120820;
+  color: #ffffff;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .pack__title {
   font-size: clamp(22px, 3vw, 24px);
-  font-weight: 600;
+  font-weight: 700;
   transition: color 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
@@ -296,6 +285,7 @@
   gap: 12px;
   font-size: clamp(13px, 2.4vw, 14px);
   color: rgba(244, 236, 255, 0.82);
+  line-height: 1.6;
 }
 
 .pack__list li {
@@ -312,8 +302,8 @@
   height: 10px;
   border-radius: 50%;
   transform: translateY(-50%);
-  background: radial-gradient(circle at 30% 30%, #ffffff 0%, var(--accent-start) 68%);
-  box-shadow: 0 0 12px color-mix(in srgb, var(--accent-start) 30%, transparent);
+  background: radial-gradient(circle, #ffffff 0%, #ffffff 32%, color-mix(in srgb, var(--accent-end) 90%, transparent) 68%, rgba(255, 255, 255, 0) 100%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-end) 30%, transparent);
 }
 
 .pack__cta {
@@ -337,13 +327,20 @@
 .pack__cta:focus-visible {
   outline: 2px solid #ffffff;
   outline-offset: 3px;
+  border-color: color-mix(in srgb, var(--accent-end) 60%, transparent);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--accent-end) 45%, transparent),
+    0 12px 24px rgba(12, 5, 24, 0.36);
+  transform: translateY(-2px);
 }
 
 .pack:hover .pack__cta,
-.pack:focus-within .pack__cta,
-.pack.is-hover .pack__cta {
+.pack:focus-within .pack__cta:not(:focus-visible),
+.pack.is-hover .pack__cta:not(:focus-visible) {
   border-color: color-mix(in srgb, var(--accent-end) 60%, transparent);
-  box-shadow: 0 12px 24px rgba(12, 5, 24, 0.36);
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--accent-end) 40%, transparent),
+    0 12px 24px rgba(12, 5, 24, 0.36);
   transform: translateY(-2px);
 }
 
@@ -370,7 +367,9 @@
 .pack__cta--primary:focus-visible {
   outline: 2px solid #ffffff;
   outline-offset: 3px;
-  box-shadow: 0 0 0 3px rgba(214, 60, 255, 0.5);
+  box-shadow:
+    0 0 0 3px rgba(214, 60, 255, 0.5),
+    0 18px 34px rgba(214, 60, 255, 0.4);
 }
 
 .pack__cta--primary:hover,
@@ -416,9 +415,9 @@
   }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 560px) {
   .addons__grid {
-    grid-template-columns: repeat(2, minmax(140px, 1fr));
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
   }
 }
 
@@ -482,6 +481,7 @@
 .addon.is-hover::after {
   opacity: 1;
   box-shadow: 0 0 16px 4px color-mix(in srgb, var(--addon-accent) 60%, transparent);
+  animation: addonPulse 1.4s ease-out;
 }
 
 .addon__title {
@@ -551,6 +551,7 @@
 .addons__cta:focus-visible {
   outline: 2px solid #ffffff;
   outline-offset: 3px;
+  box-shadow: 0 0 0 3px rgba(214, 60, 255, 0.45), 0 22px 38px rgba(214, 60, 255, 0.42);
 }
 
 [data-packs-section] [data-reveal] {
@@ -572,7 +573,8 @@
 }
 
 .is-packs-reduced .pack__cta--primary::after,
-.is-packs-reduced .addons__cta::after {
+.is-packs-reduced .addons__cta::after,
+.is-packs-reduced .addon::after {
   animation: none;
   opacity: 0.6;
 }
@@ -597,6 +599,21 @@
 
   [data-packs-section] [data-reveal] {
     transform: none;
+  }
+}
+
+@keyframes addonPulse {
+  0% {
+    transform: scale(0.8);
+    opacity: 0.65;
+  }
+  55% {
+    transform: scale(1.25);
+    opacity: 0.2;
+  }
+  100% {
+    transform: scale(0.9);
+    opacity: 0.45;
   }
 }
 

--- a/styles/packs.css
+++ b/styles/packs.css
@@ -1,0 +1,616 @@
+.packs {
+  position: relative;
+  padding: clamp(72px, 12vw, 120px) 0 clamp(88px, 14vw, 140px);
+  color: #f7f3ff;
+  background:
+    radial-gradient(120% 140% at 12% 18%, rgba(123, 76, 255, 0.22), transparent 65%),
+    radial-gradient(80% 110% at 85% 20%, rgba(255, 150, 43, 0.2), transparent 70%),
+    linear-gradient(180deg, #1a0f2f 0%, #120820 54%, #0d051a 100%);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.packs::before,
+.packs::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.packs::before {
+  background: radial-gradient(260px 260px at 18% 28%, rgba(255, 255, 255, 0.18), transparent 72%),
+    radial-gradient(320px 320px at 82% 12%, rgba(214, 60, 255, 0.18), transparent 74%),
+    radial-gradient(360px 360px at 88% 80%, rgba(35, 211, 116, 0.16), transparent 78%);
+  opacity: 0.65;
+  mix-blend-mode: screen;
+  z-index: 0;
+}
+
+.packs::after {
+  width: 2px;
+  height: 2px;
+  top: 18%;
+  left: 24%;
+  right: auto;
+  bottom: auto;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow:
+    120px -30px 0 0 rgba(255, 255, 255, 0.7),
+    260px 80px 0 0 rgba(214, 60, 255, 0.55),
+    420px -20px 0 0 rgba(123, 206, 255, 0.5),
+    560px 120px 0 0 rgba(255, 150, 43, 0.55),
+    720px 40px 0 0 rgba(255, 255, 255, 0.6),
+    -140px 60px 0 0 rgba(214, 60, 255, 0.5),
+    -260px 180px 0 0 rgba(83, 235, 165, 0.45),
+    80px 220px 0 0 rgba(255, 255, 255, 0.55),
+    360px 260px 0 0 rgba(255, 150, 43, 0.4),
+    540px 200px 0 0 rgba(214, 60, 255, 0.5);
+  opacity: 0.65;
+  animation: labs-star-twinkle 6s ease-in-out infinite alternate;
+  z-index: 0;
+}
+
+.packs__inner {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, calc(100% - clamp(36px, 10vw, 160px)));
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(48px, 9vw, 72px);
+}
+
+.packs__head {
+  display: grid;
+  justify-items: center;
+  gap: clamp(10px, 2vw, 16px);
+  text-align: center;
+}
+
+.packs__title {
+  font-size: clamp(38px, 5.6vw, 60px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: #f7f3ff;
+}
+
+.packs__title .grad-word {
+  background: linear-gradient(90deg, #ff962b 0%, #d63cff 100%);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.packs__lede {
+  font-size: clamp(16px, 2.6vw, 18px);
+  max-width: 540px;
+  color: rgba(244, 236, 255, 0.78);
+}
+
+.packs__grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(280px, 1fr));
+  gap: clamp(16px, 3vw, 24px);
+  padding: 0;
+  margin: 0;
+}
+
+@media (max-width: 1024px) {
+  .packs__grid {
+    grid-template-columns: repeat(2, minmax(280px, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .packs__grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+}
+
+.pack {
+  position: relative;
+  display: grid;
+  gap: clamp(12px, 2.4vw, 18px);
+  padding: clamp(18px, 3vw, 24px);
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(155deg, rgba(32, 18, 60, 0.72) 0%, rgba(16, 8, 32, 0.7) 100%);
+  box-shadow: 0 18px 32px rgba(9, 3, 20, 0.28);
+  transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  color: inherit;
+  will-change: transform;
+  overflow: hidden;
+}
+
+.pack::before,
+.pack::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.pack::after {
+  mix-blend-mode: screen;
+}
+
+.pack::before {
+  padding: 0;
+  border-radius: inherit;
+}
+
+.pack[data-accent="starter"] {
+  --accent-start: #2aa9ff;
+  --accent-end: #7bd6ff;
+}
+
+.pack[data-accent="builder"] {
+  --accent-start: #8c4bff;
+  --accent-end: #b08cff;
+}
+
+.pack[data-accent="engine"] {
+  --accent-start: #ff6a2a;
+  --accent-end: #ff9a50;
+}
+
+.pack[data-accent="growth"] {
+  --accent-start: #23d374;
+  --accent-end: #54e6b1;
+}
+
+.pack[data-accent]::after {
+  background-image:
+    radial-gradient(220px 160px at 78% 48%, rgba(255, 255, 255, 0.18), transparent 74%),
+    radial-gradient(280px 200px at 82% 52%, color-mix(in srgb, var(--accent-end) 62%, transparent), transparent 72%),
+    linear-gradient(180deg, color-mix(in srgb, var(--accent-start) 54%, transparent) 0%, transparent 72%);
+  background-repeat: no-repeat;
+  background-position:
+    74% 52%,
+    78% 52%,
+    calc(100% - clamp(10px, 2.4vw, 16px)) 50%;
+  background-size:
+    340px 220px,
+    420px 260px,
+    clamp(8px, 2vw, 12px) 72%;
+}
+
+.pack:hover,
+.pack:focus-within,
+.pack.is-hover {
+  transform: translateY(-3px) scale(1.01);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 22px 38px rgba(12, 5, 28, 0.36);
+}
+
+.pack:hover::after,
+.pack:hover::before,
+.pack:focus-within::after,
+.pack:focus-within::before,
+.pack.is-hover::after,
+.pack.is-hover::before {
+  opacity: 1;
+}
+
+.pack__badge {
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #f7f3ff;
+  background: linear-gradient(145deg, rgba(32, 18, 60, 0.86) 0%, rgba(14, 6, 26, 0.86) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 10px 22px rgba(9, 3, 20, 0.36);
+  pointer-events: none;
+}
+
+.pack.is-featured {
+  padding-top: clamp(26px, 4vw, 32px);
+}
+
+.pack.is-featured::before {
+  inset: -2px;
+  background: linear-gradient(135deg, rgba(255, 150, 43, 0.7), rgba(214, 60, 255, 0.72));
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  -webkit-mask-composite: xor;
+  padding: 2px;
+  border-radius: 24px;
+}
+
+.pack.is-featured::before,
+.pack.is-featured::after {
+  opacity: 1;
+}
+
+.pack.is-featured:hover .pack__badge,
+.pack.is-featured:focus-within .pack__badge,
+.pack.is-featured.is-hover .pack__badge {
+  color: #f5c542;
+}
+
+.pack__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  color: #120820;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.pack__title {
+  font-size: clamp(22px, 3vw, 24px);
+  font-weight: 600;
+  transition: color 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.pack:hover .pack__title,
+.pack:focus-within .pack__title,
+.pack.is-hover .pack__title {
+  color: #f5c542;
+}
+
+.pack__desc {
+  font-size: clamp(14px, 2.4vw, 15px);
+  color: rgba(244, 236, 255, 0.78);
+}
+
+.pack__price {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: clamp(18px, 3vw, 20px);
+}
+
+.pack__price .val {
+  font-size: clamp(34px, 5vw, 38px);
+  font-weight: 700;
+  text-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+}
+
+.pack__price .unit {
+  font-size: clamp(13px, 2.6vw, 15px);
+  color: rgba(244, 236, 255, 0.68);
+}
+
+.pack__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+  font-size: clamp(13px, 2.4vw, 14px);
+  color: rgba(244, 236, 255, 0.82);
+}
+
+.pack__list li {
+  position: relative;
+  padding-left: 20px;
+}
+
+.pack__list li::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  transform: translateY(-50%);
+  background: radial-gradient(circle at 30% 30%, #ffffff 0%, var(--accent-start) 68%);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--accent-start) 30%, transparent);
+}
+
+.pack__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: clamp(44px, 4.6vw, 48px);
+  border-radius: 14px;
+  padding: 0 clamp(18px, 4vw, 26px);
+  font-weight: 600;
+  font-size: 15px;
+  color: #f7f3ff;
+  background: linear-gradient(155deg, rgba(26, 18, 42, 0.72), rgba(20, 10, 38, 0.74));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  will-change: transform;
+}
+
+.pack__cta:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 3px;
+}
+
+.pack:hover .pack__cta,
+.pack:focus-within .pack__cta,
+.pack.is-hover .pack__cta {
+  border-color: color-mix(in srgb, var(--accent-end) 60%, transparent);
+  box-shadow: 0 12px 24px rgba(12, 5, 24, 0.36);
+  transform: translateY(-2px);
+}
+
+.pack__cta--primary {
+  background: linear-gradient(120deg, #ff962b 0%, #d63cff 100%);
+  box-shadow: 0 16px 32px rgba(214, 60, 255, 0.28);
+  color: #fff;
+  border: none;
+  position: relative;
+  overflow: hidden;
+}
+
+.pack__cta--primary::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 50%, rgba(255, 255, 255, 0.62), rgba(255, 255, 255, 0) 60%);
+  transform: scale(0.6);
+  opacity: 0.8;
+  animation: packsSparkle 3s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.pack__cta--primary:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 3px;
+  box-shadow: 0 0 0 3px rgba(214, 60, 255, 0.5);
+}
+
+.pack__cta--primary:hover,
+.pack__cta--primary:focus-visible,
+.pack__cta--primary.is-hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 18px 34px rgba(214, 60, 255, 0.4);
+}
+
+.addons {
+  display: grid;
+  gap: clamp(28px, 6vw, 40px);
+}
+
+.addons__head {
+  text-align: center;
+  display: grid;
+  gap: 12px;
+}
+
+.addons__title {
+  font-size: clamp(26px, 4vw, 32px);
+  font-weight: 600;
+}
+
+.addons__lede {
+  font-size: clamp(14px, 2.4vw, 16px);
+  color: rgba(244, 236, 255, 0.78);
+}
+
+.addons__grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(180px, 1fr));
+  gap: clamp(14px, 3vw, 22px);
+}
+
+@media (max-width: 920px) {
+  .addons__grid {
+    grid-template-columns: repeat(2, minmax(180px, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .addons__grid {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+}
+
+.addon {
+  position: relative;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 6px;
+  padding: clamp(18px, 3vw, 24px);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: linear-gradient(150deg, rgba(32, 18, 60, 0.72), rgba(18, 8, 34, 0.68));
+  box-shadow: 0 16px 28px rgba(9, 3, 20, 0.26);
+  transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  will-change: transform;
+}
+
+.addon::after {
+  content: "";
+  position: absolute;
+  top: clamp(14px, 2vw, 18px);
+  right: clamp(14px, 2vw, 18px);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--addon-accent, #ff962b) 88%, transparent);
+  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.6);
+  opacity: 0;
+  transition: opacity 200ms ease, box-shadow 400ms ease;
+}
+
+.addon[data-accent="ai"] {
+  --addon-accent: #8c4bff;
+}
+
+.addon[data-accent="swiftpay"] {
+  --addon-accent: #ff962b;
+}
+
+.addon[data-accent="app"] {
+  --addon-accent: #2aa9ff;
+}
+
+.addon[data-accent="devops"] {
+  --addon-accent: #23d374;
+}
+
+.addon:hover,
+.addon:focus-within,
+.addon.is-hover {
+  transform: translateY(-3px) scale(1.01);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 18px 32px rgba(12, 5, 28, 0.34);
+}
+
+.addon:hover::after,
+.addon:focus-within::after,
+.addon.is-hover::after {
+  opacity: 1;
+  box-shadow: 0 0 16px 4px color-mix(in srgb, var(--addon-accent) 60%, transparent);
+}
+
+.addon__title {
+  font-size: clamp(18px, 3vw, 20px);
+  font-weight: 600;
+  transition: color 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.addon:hover .addon__title,
+.addon:focus-within .addon__title,
+.addon.is-hover .addon__title {
+  color: #f5c542;
+}
+
+.addon__price {
+  font-size: clamp(15px, 2.4vw, 16px);
+  color: rgba(244, 236, 255, 0.8);
+}
+
+.addons__ctaRow {
+  display: grid;
+  gap: clamp(16px, 3vw, 24px);
+  justify-items: center;
+  text-align: center;
+}
+
+.addons__prompt {
+  max-width: 560px;
+  font-size: clamp(14px, 2.4vw, 16px);
+  color: rgba(244, 236, 255, 0.78);
+}
+
+.addons__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: clamp(44px, 4.6vw, 48px);
+  padding: 0 clamp(22px, 5vw, 32px);
+  border-radius: 16px;
+  font-weight: 600;
+  font-size: 16px;
+  color: #fff;
+  background: linear-gradient(120deg, #ff962b 0%, #d63cff 100%);
+  box-shadow: 0 18px 34px rgba(214, 60, 255, 0.32);
+  transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.addons__cta::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 50%, rgba(255, 255, 255, 0.55), transparent 60%);
+  transform: scale(0.6);
+  opacity: 0.8;
+  animation: packsSparkle 3.4s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.addons__cta:hover,
+.addons__cta:focus-visible {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 22px 38px rgba(214, 60, 255, 0.42);
+}
+
+.addons__cta:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 3px;
+}
+
+[data-packs-section] [data-reveal] {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 420ms ease, transform 420ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.is-packs-js [data-packs-section] [data-reveal].is-in {
+  opacity: 1;
+  transform: none;
+}
+
+.is-packs-reduced .pack,
+.is-packs-reduced .pack__cta,
+.is-packs-reduced .addon,
+.is-packs-reduced .addons__cta {
+  transition-duration: 0ms;
+}
+
+.is-packs-reduced .pack__cta--primary::after,
+.is-packs-reduced .addons__cta::after {
+  animation: none;
+  opacity: 0.6;
+}
+
+.is-packs-reduced [data-packs-section] [data-reveal] {
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pack,
+  .pack__cta,
+  .addon,
+  .addons__cta {
+    transition-duration: 0ms;
+  }
+
+  .pack__cta--primary::after,
+  .addons__cta::after {
+    animation: none;
+    opacity: 0.6;
+  }
+
+  [data-packs-section] [data-reveal] {
+    transform: none;
+  }
+}
+
+@keyframes packsSparkle {
+  0% {
+    transform: scale(0.6);
+    opacity: 0.65;
+  }
+  50% {
+    transform: scale(1.25);
+    opacity: 0.2;
+  }
+  100% {
+    transform: scale(0.6);
+    opacity: 0.65;
+  }
+}


### PR DESCRIPTION
## Summary
- add the "Choose Your Pack" pricing section with four plans, add-ons, and CTA between Labs and Process
- create dedicated packs stylesheet for the gradient backdrop, responsive grid, hover micro-interactions, and reduced-motion support
- add a packs module to manage reveal animations, hover/focus parity, CTA target enforcement, and reduced-motion toggling

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dae31b36ec832fbd08e69729645736