### PR TITLE
Adjust IntersectionObserver threshold for portfolio section

### DIFF
--- a/scripts/portfolio.js
+++ b/scripts/portfolio.js
@@ -67,7 +67,7 @@
     const createObserver = () => new IntersectionObserver(handleIntersection, {
       root: null,
       rootMargin: '0px 0px -12% 0px',
-      threshold: 0.35,
+      threshold: 0.12,
     });
 
     let observer = createObserver();


### PR DESCRIPTION
## Summary
- lower the portfolio IntersectionObserver threshold to 0.12 to tweak reveal timing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc62235220832fba320a92445af37b