### PR TITLE
Lower labs reveal threshold and tweak reveal stagger

### DIFF
--- a/scripts/labs.js
+++ b/scripts/labs.js
@@ -283,7 +283,7 @@ if (labsSection) {
         seen.add(entry.target);
 
         const index = Number(entry.target.dataset.revealIndex || 0);
-        const delay = Math.min(80 + index * 20, 220);
+        const delay = Math.min(60 + index * 18, 200);
 
         requestAnimationFrame(() => {
           window.setTimeout(() => {
@@ -298,7 +298,7 @@ if (labsSection) {
       });
     }, {
       rootMargin: '0px 0px -10%',
-      threshold: 0.3
+      threshold: 0.12
     });
 
     revealItems.forEach((item) => observer.observe(item));


### PR DESCRIPTION
## Summary
- lower the labs IntersectionObserver threshold to 0.12 while keeping the existing root margin
- tune the stagger delay curve so earlier triggers still produce smooth reveal pacing

## Testing
- Manual verification by scrolling the Labs section in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dc621a44fc832f937acb25f53e7ca7