### PR TITLE
Adjust services observer sensitivity

### DIFF
--- a/scripts/services.js
+++ b/scripts/services.js
@@ -37,7 +37,7 @@
             }
           }
         },
-        { threshold: 0.35, rootMargin: '0px 0px -10% 0px' }
+        { threshold: 0.12, rootMargin: '0px 0px -10% 0px' }
       );
       cards.forEach((c) => !c.classList.contains('is-inview') && io.observe(c));
     };


### PR DESCRIPTION
## Summary
- lower the IntersectionObserver threshold for services cards to make reveals trigger slightly earlier while keeping the existing behavior intact

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc621f95c8832f87fd84f3b3e71171