### PR TITLE
Adjust labs grid responsiveness and sticky CTA

### DIFF
--- a/styles/labs.css
+++ b/styles/labs.css
@@ -148,9 +148,13 @@
 }
 
 .labs-beta-cta {
+  position: sticky;
+  bottom: calc(clamp(20px, 5vw, 32px) + env(safe-area-inset-bottom));
   display: flex;
   justify-content: center;
   margin-top: clamp(36px, 6vw, 52px);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 3;
 }
 
 .labs-beta-button {
@@ -231,7 +235,7 @@
   box-shadow: 0 12px 28px rgba(10, 2, 28, 0.42);
 }
 
-@media (min-width: 768px) {
+@media (min-width: 640px) {
   .labs-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -240,6 +244,12 @@
 @media (min-width: 1200px) {
   .labs-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .labs-beta-cta {
+    position: static;
+    bottom: auto;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the Labs grid breakpoints so it becomes two-up from 640px and three-up on the wide desktop breakpoint without changing the gaps
- update the Labs beta call-to-action to stick to the bottom on narrow screens with safe-area support while remaining centered on desktop

## Testing
- browser_container.run_playwright_script (375px viewport)
- browser_container.run_playwright_script (720px viewport)
- browser_container.run_playwright_script (1280px viewport)


------
https://chatgpt.com/codex/tasks/task_e_68dc6329a41c832f95d8bf3c914fef5d