### PR TITLE
Adjust portfolio grid breakpoint

### DIFF
--- a/styles/portfolio.css
+++ b/styles/portfolio.css
@@ -91,7 +91,7 @@
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
-@media (min-width: 720px) {
+@media (min-width: 640px) {
   #portfolio .portfolio__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 


### PR DESCRIPTION
## Summary
- lower the portfolio grid breakpoint so the two-column layout begins at 640px
- manually review the portfolio section between 640px and desktop widths to confirm spacing, overlays, and CTA rows remain balanced

## Testing
- Manual QA at 640px, 860px, and 1280px viewport widths

------
https://chatgpt.com/codex/tasks/task_e_68dc632ce154832fa2ee4130b46ee63e