### PR TITLE
Add smooth scrolling with header offset compensation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -914,6 +914,7 @@
   <script src="./scripts/portfolio.js" type="module"></script>
   <script src="./scripts/labs.js" type="module"></script>
   <script src="./scripts/packs.js" type="module"></script>
+  <script src="./scripts/smooth-scroll.js" type="module"></script>
   <script src="./scripts/process.js" defer></script>
 </body>
 </html>

--- a/scripts/smooth-scroll.js
+++ b/scripts/smooth-scroll.js
@@ -1,0 +1,132 @@
+const root = document.documentElement;
+const header = document.querySelector('.ss-header');
+const mobileMenu = document.getElementById('mobileMenu');
+const hamburger = document.querySelector('.hamburger');
+const prefersReducedMotion = window.matchMedia
+  ? window.matchMedia('(prefers-reduced-motion: reduce)')
+  : { matches: false };
+
+root.classList.remove('no-js');
+
+let headerHeight = 0;
+let resizeTimer;
+
+function measureHeader() {
+  headerHeight = header ? header.getBoundingClientRect().height : 0;
+  root.style.setProperty('--header-offset', `${headerHeight}px`);
+}
+
+function scheduleMeasure() {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(measureHeader, 150);
+}
+
+function closeMobileMenu() {
+  if (mobileMenu) {
+    mobileMenu.hidden = true;
+  }
+  document.body.style.overflow = '';
+  hamburger?.setAttribute('aria-expanded', 'false');
+}
+
+function scrollToTarget(target, updateHash = true) {
+  if (!target) return;
+
+  const targetRect = target.getBoundingClientRect();
+  const currentScroll = window.scrollY ?? window.pageYOffset ?? 0;
+  const targetTop = currentScroll + targetRect.top - (headerHeight + 16);
+  const top = Math.max(targetTop, 0);
+
+  window.scrollTo({
+    top,
+    behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
+  });
+
+  if (updateHash && target.id) {
+    const hash = `#${target.id}`;
+    if (hash !== window.location.hash) {
+      if (history.pushState) {
+        history.pushState(null, '', hash);
+        window.dispatchEvent(new Event('hashchange'));
+      } else {
+        window.location.hash = hash;
+      }
+    }
+  }
+
+  if (typeof target.focus === 'function') {
+    setTimeout(() => {
+      const previousTabIndex = target.getAttribute('tabindex');
+      target.setAttribute('tabindex', '-1');
+      target.focus({ preventScroll: true });
+      if (previousTabIndex === null) {
+        target.removeAttribute('tabindex');
+      } else {
+        target.setAttribute('tabindex', previousTabIndex);
+      }
+    }, 300);
+  }
+}
+
+function getTargetFromLink(link) {
+  if (!link) return null;
+
+  if (link.hasAttribute('data-scroll-to')) {
+    const selector = link.dataset.scrollTo?.trim();
+    if (!selector) return null;
+    if (selector.startsWith('#')) {
+      const id = selector.slice(1);
+      return document.getElementById(id) ?? document.querySelector(selector);
+    }
+    return document.querySelector(selector);
+  }
+
+  const href = link.getAttribute('href');
+  if (!href || !href.startsWith('#')) return null;
+  const id = href.slice(1);
+  if (!id) return null;
+  return document.getElementById(id) ?? document.querySelector(href);
+}
+
+document.addEventListener('click', (event) => {
+  if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return;
+  }
+
+  const origin = event.target instanceof Element ? event.target : null;
+  const link = origin?.closest("a[href^="#"]:not([href="#"]), [data-scroll-to]");
+  if (!link) return;
+
+  const target = getTargetFromLink(link);
+  if (!target) return;
+
+  event.preventDefault();
+  closeMobileMenu();
+
+  requestAnimationFrame(() => {
+    measureHeader();
+    scrollToTarget(target);
+  });
+});
+
+window.addEventListener('load', () => {
+  measureHeader();
+
+  const hash = window.location.hash;
+  if (!hash) return;
+
+  const target = document.getElementById(hash.replace(/^#/, ''));
+  if (!target) return;
+
+  requestAnimationFrame(() => {
+    measureHeader();
+    scrollToTarget(target, false);
+  });
+});
+
+window.addEventListener('resize', scheduleMeasure);
+document.addEventListener('header:measure', () => {
+  requestAnimationFrame(measureHeader);
+});
+
+measureHeader();

--- a/styles/global.css
+++ b/styles/global.css
@@ -41,10 +41,15 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
 
   /* Layout */
   --container: 1200px;
+  --header-offset: 0px;
 }
 
 /* ---------- Utilities ---------- */
 .container{width:min(var(--container), calc(100% - 32px)); margin-inline:auto}
+
+[id]{scroll-margin-top:calc(var(--header-offset) + 16px)}
+html.no-js{scroll-behavior:smooth}
+html.no-js [id]{scroll-margin-top:calc(72px + 16px)}
 
 /* Headings & type */
 .display{


### PR DESCRIPTION
## Summary
- add a smooth-scroll module that measures the header, updates the CSS offset, and intercepts in-page navigation with focus management
- define global scroll offset styles and a no-JS fallback so anchored sections respect the header height
- wire the module into the page and mark the root element for progressive enhancement

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dccf229c90832fab69519dbadf91d1