### PR TITLE
Make header sticky

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -4,7 +4,7 @@
 
 .ss-header{
   /* Overlay the hero with a barely-there glass tint so the gradient shines through */
-  position:absolute;
+  position:sticky;
   top:0;
   left:0;
   right:0;


### PR DESCRIPTION
## Summary
- switch the header container to `position: sticky` so it remains pinned while scrolling
- retain the glass overlay values to preserve the layered appearance for scroll-state modifiers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcf609cdb0832f9824d5db81ce8479