### PR TITLE
Adjust root element height to allow full scroll

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -5,7 +5,7 @@
 
 /* ---------- Reset ---------- */
 *,*::before,*::after{box-sizing:border-box}
-html,body{height:100%}
+html,body{min-height:100%}
 body{
   margin:0;
   font:500 16px/1.6 "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- replace the fixed 100% height on the html/body selector with a min-height so the page can extend with its content and keep sticky layout behavior intact

## Testing
- Manual Playwright-driven UI smoke test covering sticky header and anchor offsets

------
https://chatgpt.com/codex/tasks/task_e_68dcf8f12e84832f9c9dec968ebe4ff0