### PR TITLE
Update header icons with contact links

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,26 +43,33 @@
       </nav>
 
       <div class="header-icons">
-        <!-- search -->
-        <button class="icon-btn" aria-label="Search">
+        <!-- email -->
+        <a class="icon-btn" aria-label="Email" href="mailto:hello@swiftsend.dev">
           <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <circle cx="11" cy="11" r="7"></circle>
-            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            <rect x="3" y="5" width="18" height="14" rx="2"></rect>
+            <polyline points="3 7.5 12 13 21 7.5"></polyline>
           </svg>
-        </button>
+        </a>
 
         <!-- phone -->
-        <a class="icon-btn" aria-label="Call" href="tel:+1">
+        <a class="icon-btn" aria-label="Call" href="tel:+18005550123">
           <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2 4.11 2 2 0 0 1 4 2h3a2 2 0 0 1 2 1.72c.12.9.33 1.78.62 2.63a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.45-1.2a2 2 0 0 1 2.11-.45c.85.29 1.73.5 2.63.62A2 2 0 0 1 22 16.92z"></path>
           </svg>
         </a>
 
-        <!-- profile -->
-        <button class="icon-btn" aria-label="Account">
+        <!-- message -->
+        <a class="icon-btn" aria-label="Message" href="sms:+18005550123" data-sms-link="sms:+18005550123">
           <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <path d="M20 21a8 8 0 1 0-16 0"></path>
-            <circle cx="12" cy="7" r="4"></circle>
+            <path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z"></path>
+          </svg>
+        </a>
+
+        <!-- search -->
+        <button class="icon-btn" aria-label="Search">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
           </svg>
         </button>
 


### PR DESCRIPTION
## Summary
- replace the header account/phone controls with dedicated email, phone, and message anchors
- keep the search button and hamburger toggle positioned after the new contact anchors

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd9974ead4832fa6301e7644d88a0b